### PR TITLE
Fix PostgreSQL StorageClass issue for k8s-deploy

### DIFF
--- a/kubernetes/base/database/postgres-pvc.yaml
+++ b/kubernetes/base/database/postgres-pvc.yaml
@@ -12,4 +12,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: standard


### PR DESCRIPTION
## Summary
Fixes PostgreSQL pod startup failure in `make k8s-deploy` by removing hardcoded StorageClass.

## Problem
```
Warning  ProvisioningFailed  persistentvolume-controller  storageclass.storage.k8s.io "standard" not found
```

The PVC was hardcoded to use `storageClassName: standard` but the cluster has DigitalOcean storage classes:
- `do-block-storage` (default)
- `do-block-storage-retain` 
- `do-block-storage-xfs`
- `do-block-storage-xfs-retain`

## Solution
- Removed hardcoded `storageClassName: standard` from postgres-pvc.yaml
- Now uses the default StorageClass automatically (`do-block-storage`)
- Makes the deployment more portable across different K8s environments

## Test plan
- [x] Verified available StorageClasses in cluster
- [ ] Test `make k8s-deploy` - PostgreSQL pod should start successfully
- [ ] Verify PVC provisions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)