### PR TITLE
Fix E2E test performance and networking issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,27 @@ jobs:
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
     
-    - name: Install Playwright
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: |
+          ~/.cache/playwright
+          ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+    
+    - name: Install dependencies
       run: |
         cd frontend
         npm ci
+    
+    - name: Install Playwright browsers
+      run: |
+        cd frontend
         npx playwright install --with-deps
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
     
     - name: Start services with docker compose
       run: |

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,10 +24,15 @@ WORKDIR /app
 RUN addgroup --gid 1001 nodejs && \
     adduser --uid 1001 --gid 1001 nextjs
 
+# Copy package files for production install
+COPY --from=builder /app/package*.json ./
+
+# Install dependencies including Next.js for runtime
+RUN npm ci --omit=dev && npm install next && npm cache clean --force
+
 # Copy built application
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/.next ./.next
 
 # Change ownership
 RUN chown -R nextjs:nodejs /app
@@ -43,4 +48,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:3000 || exit 1
 
 # Run the application
-CMD ["node", "server.js"]
+CMD ["npx", "next", "start"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  output: 'standalone',
   images: {
     unoptimized: true,
   },
@@ -9,7 +8,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.BACKEND_API_URL || 'http://api-gateway:80'}/api/:path*`,
+        destination: `${process.env.BACKEND_API_URL || 'http://api-gateway:8080'}/api/:path*`,
       },
     ]
   },


### PR DESCRIPTION
- Fix Next.js config: correct API Gateway port from 80 to 8080 for container networking
- Fix Dockerfile: use standard Next.js build with runtime dependencies instead of standalone mode
- Add Playwright browser caching to CI to reduce E2E test installation time
- Tests now successfully connect to API Gateway, resolving hostname resolution errors

🤖 Generated with [Claude Code](https://claude.ai/code)