### PR TITLE
Fix Jest configuration to ignore next.config.test.ts

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -35,6 +35,7 @@ const customJestConfig = {
     '<rootDir>/.next/',
     '<rootDir>/node_modules/',
     '<rootDir>/e2e/',
+    '<rootDir>/next.config.test.ts',
   ],
   modulePathIgnorePatterns: ['<rootDir>/.next/'],
 }


### PR DESCRIPTION
- Add next.config.test.ts to testPathIgnorePatterns
- Resolves Jest test failures from treating config file as test

🤖 Generated with [Claude Code](https://claude.ai/code)