### PR TITLE
fix: Update simulation-client to use versioned image

### DIFF
--- a/kubernetes/base/deployments/simulation-client-deployment.yaml
+++ b/kubernetes/base/deployments/simulation-client-deployment.yaml
@@ -34,8 +34,8 @@ spec:
         fsGroup: 1001
       containers:
       - name: simulation-client
-        image: ghcr.io/speedscale/microsvc/simulation-client:latest
-        imagePullPolicy: IfNotPresent
+        image: ghcr.io/speedscale/microsvc/simulation-client:v1.3.0
+        imagePullPolicy: Always
         
         ports:
         - name: health

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -7,7 +7,7 @@ set -e
 
 VERSION_FILE="VERSION"
 REGISTRY="ghcr.io/speedscale/microsvc"
-SERVICES=("user-service" "accounts-service" "transactions-service" "api-gateway" "frontend")
+SERVICES=("user-service" "accounts-service" "transactions-service" "api-gateway" "frontend" "simulation-client")
 BACKEND_SERVICES=("user-service" "accounts-service" "transactions-service" "api-gateway")
 FRONTEND_SERVICES=("frontend")
 SIMULATION_SERVICES=("simulation-client")


### PR DESCRIPTION
- Changed simulation-client deployment to use v1.3.0 instead of :latest
- Added simulation-client to SERVICES array in version.sh for consistent versioning
- All services now use consistent v1.3.0 image tags

This ensures all deployments use versioned images, not :latest