### PR TITLE
fix: use Spring Boot 3 launcher in service manifests

### DIFF
--- a/kubernetes/base/deployments/accounts-service-deployment.yaml
+++ b/kubernetes/base/deployments/accounts-service-deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - name: accounts-service
         image: ghcr.io/speedscale/microsvc/accounts-service:v1.4.0
         imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]
         ports:
         - containerPort: 8080
           name: http

--- a/kubernetes/base/deployments/api-gateway-deployment.yaml
+++ b/kubernetes/base/deployments/api-gateway-deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - name: api-gateway
         image: ghcr.io/speedscale/microsvc/api-gateway:v1.4.0
         imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]
         ports:
         - containerPort: 8080
           name: http

--- a/kubernetes/base/deployments/transactions-service-deployment.yaml
+++ b/kubernetes/base/deployments/transactions-service-deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - name: transactions-service
         image: ghcr.io/speedscale/microsvc/transactions-service:v1.4.0
         imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]
         ports:
         - containerPort: 8080
           name: http


### PR DESCRIPTION
## Summary
- update `transactions-service`, `accounts-service`, and `api-gateway` deployment commands to launch with `org.springframework.boot.loader.launch.JarLauncher`
- keep image tags unchanged and fix startup behavior at the manifest layer

## Why
These services currently fail at startup with:
`ClassNotFoundException: org.springframework.boot.loader.JarLauncher`
because Spring Boot 3 layered jars use `org.springframework.boot.loader.launch.JarLauncher`.