### PR TITLE
fix: tune startup probes and memory for staging services

### DIFF
--- a/kubernetes/base/deployments/accounts-service-deployment.yaml
+++ b/kubernetes/base/deployments/accounts-service-deployment.yaml
@@ -52,10 +52,10 @@ spec:
             name: accounts-service-config
         resources:
           requests:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "50m"
           limits:
-            memory: "256Mi"
+            memory: "768Mi"
             cpu: "150m"
         startupProbe:
           tcpSocket:
@@ -63,22 +63,24 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
           timeoutSeconds: 5
-          failureThreshold: 24
+          failureThreshold: 90
         livenessProbe:
           httpGet:
             path: /actuator/health/liveness
             port: 8080
+          initialDelaySeconds: 240
           periodSeconds: 30
           timeoutSeconds: 5
-          failureThreshold: 3
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /actuator/health/readiness
             port: 8080
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine

--- a/kubernetes/base/deployments/api-gateway-deployment.yaml
+++ b/kubernetes/base/deployments/api-gateway-deployment.yaml
@@ -47,28 +47,35 @@ spec:
             name: api-gateway-config
         resources:
           requests:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "50m"
           limits:
-            memory: "256Mi"
+            memory: "768Mi"
             cpu: "150m"
+        startupProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 90
         livenessProbe:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 30
+          initialDelaySeconds: 240
           periodSeconds: 30
           timeoutSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
       initContainers:
       - name: wait-for-services
         image: busybox:1.35

--- a/kubernetes/base/deployments/transactions-service-deployment.yaml
+++ b/kubernetes/base/deployments/transactions-service-deployment.yaml
@@ -52,28 +52,35 @@ spec:
             name: transactions-service-config
         resources:
           requests:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "50m"
           limits:
-            memory: "256Mi"
+            memory: "768Mi"
             cpu: "150m"
+        startupProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 90
         livenessProbe:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 30
+          initialDelaySeconds: 240
           periodSeconds: 30
           timeoutSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine

--- a/kubernetes/base/deployments/user-service-deployment.yaml
+++ b/kubernetes/base/deployments/user-service-deployment.yaml
@@ -50,28 +50,35 @@ spec:
             name: user-service-config
         resources:
           requests:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "50m"
           limits:
-            memory: "256Mi"
+            memory: "768Mi"
             cpu: "150m"
+        startupProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 90
         livenessProbe:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 30
+          initialDelaySeconds: 240
           periodSeconds: 30
           timeoutSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine


### PR DESCRIPTION
## Summary
- increase memory requests/limits for core Java services (`user-service`, `accounts-service`, `transactions-service`, `api-gateway`)
- add or extend startup probes for slow Spring Boot startup paths
- delay liveness/readiness checks so services are not killed before JVM warmup and Flyway/JPA initialization complete

## Why
Staging pods were repeatedly failing startup and being restarted by probes before app initialization completed; some services were also OOM-killed under the previous 256Mi limit.