### PR TITLE
Fix: Microsvc user service returns 500 instead of 404 for a missing user

### DIFF
--- a/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.146257Z.md
+++ b/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.146257Z.md
@@ -1,0 +1,43 @@
+### REQUEST ###
+```
+GET http://localhost:8081/actuator/health/liveness HTTP/1.1
+Accept: */*
+Host: localhost:8080
+User-Agent: curl/8.7.1
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/vnd.spring-boot.actuator.v3+json
+Date: Tue\, 07 Apr 2026 01:49:56 GMT
+Expires: 0
+Pragma: no-cache
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "status": "UP"
+}
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: c5abd34d-27c2-4ec6-8cdb-f8f7d104ddf3
+ts: 2026-04-07T01:49:56.146257Z
+duration: 83ms
+tags: captureMode=proxy, clientID=1, file=proxymock/recorded-complete/localhost/2026-03-31_22-51-53.991444Z.json, generatorID=1, k8sClusterName=, msgNum=0, proxyProtocol=tcp:http, proxyType=dual, refUuid=9645c810-aa7b-4c28-aaa3-b56e42ce0dcc, reverseProxyHost=localhost, reverseProxyPort=8080, sequence=869, source=generator
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-04-07T01:49:56.146257Z","l7protocol":"http","duration":83,"tags":{"captureMode":"proxy","clientID":"1","file":"proxymock/recorded-complete/localhost/2026-03-31_22-51-53.991444Z.json","generatorID":"1","k8sClusterName":"","msgNum":"0","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","refUuid":"9645c810-aa7b-4c28-aaa3-b56e42ce0dcc","reverseProxyHost":"localhost","reverseProxyPort":"8080","sequence":"869","source":"generator"},"uuid":"xavTTSfCTsaM2/j30QTd8w==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","tech":"JSON","network_address":"localhost:8081","command":"GET","location":"/actuator/health/liveness","status":"200 ","http":{"req":{"url":"/actuator/health/liveness","uri":"/actuator/health/liveness","version":"1.1","method":"GET","host":"localhost"},"res":{"contentType":"application/vnd.spring-boot.actuator.v3+json","statusCode":200,"statusMessage":"200 "}},"tokenList":{"URI:localhost:8080":{"id":"URI:localhost:8080","tokens":[{"uuid":"xavTTSfCTsaM2/j30QTd8w==","token":{"location":"http.req.headers.Host[0]","pattern":"DATA_PATTERN_URI","replacementValue":"bG9jYWxob3N0OjgwODA="}}]}},"events":[{"uuid":"749af73e-361a-4801-a432-723b6902a5dd","ts":"2026-04-07T01:49:56.145949Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"dbc88fb7-2f5c-40e5-8801-c856f7d08394","ts":"2026-04-07T01:49:56.145956Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: localhost","actorType":"GENERATOR"},{"uuid":"88975d72-05d1-44d2-a712-d9c18343c448","ts":"2026-04-07T01:49:56.145958Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_hostname(): localhost","actorType":"GENERATOR"},{"uuid":"378a4c45-3f19-4d8e-a06f-d3b8029f736d","ts":"2026-04-07T01:49:56.145966Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=localhost,requiredSecrets=[]): localhost","actorType":"GENERATOR"},{"uuid":"18d9a95e-7da3-41cc-a51d-f7921e9ba2be","ts":"2026-04-07T01:49:56.145968Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: localhost","actorType":"GENERATOR"},{"uuid":"46fa688f-5095-4e8d-a294-7ecc326bee78","ts":"2026-04-07T01:49:56.145986Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"24fcc1d8-52ea-41f4-9407-6be519fdbce3","ts":"2026-04-07T01:49:56.145989Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: 8081","actorType":"GENERATOR"},{"uuid":"95278171-5533-46f0-b227-29c3eed13180","ts":"2026-04-07T01:49:56.145990Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_port(): 8081","actorType":"GENERATOR"},{"uuid":"79b3ec69-6c49-4988-86f9-c5a61d2a8ca6","ts":"2026-04-07T01:49:56.145993Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=8081,requiredSecrets=[]): 8081","actorType":"GENERATOR"},{"uuid":"ef89bfaa-6015-460b-8821-95e9e57768c6","ts":"2026-04-07T01:49:56.145996Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: 8081","actorType":"GENERATOR"},{"uuid":"ed82a2e4-e041-4b1c-9f5d-c3a46ac61f56","ts":"2026-04-07T01:49:56.233776Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])"},{"uuid":"ca50bc45-6872-4eb9-8fe2-53a81d495545","ts":"2026-04-07T01:49:56.233782Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: localhost"},{"uuid":"e9d1ec39-3634-485e-bdd7-b3ba26f278e1","ts":"2026-04-07T01:49:56.233783Z","source":"generator","operation":"transform","message":"[GEN/RES] target_hostname(): localhost"},{"uuid":"09aad446-bf84-4aa6-9722-01c1295de51c","ts":"2026-04-07T01:49:56.233788Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=localhost,requiredSecrets=[]): localhost"},{"uuid":"767ff081-854c-4b2d-aa55-de55519aa5b1","ts":"2026-04-07T01:49:56.233788Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: localhost"},{"uuid":"264cadd5-1ed2-459d-ac3a-74cb97e6eb7f","ts":"2026-04-07T01:49:56.233797Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])"},{"uuid":"0c55ad66-d332-429f-8fa4-b9b6627d02e1","ts":"2026-04-07T01:49:56.233798Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: 8081"},{"uuid":"a41f420f-99f2-4076-b617-34927da1e69c","ts":"2026-04-07T01:49:56.233799Z","source":"generator","operation":"transform","message":"[GEN/RES] target_port(): 8081"},{"uuid":"77c0736d-0a5f-447f-810a-696900fd8c7b","ts":"2026-04-07T01:49:56.233800Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=8081,requiredSecrets=[]): 8081"},{"uuid":"1d009ceb-5d17-439f-9f5c-ca7fde3d304f","ts":"2026-04-07T01:49:56.233801Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: 8081"}],"netinfo":{"startTime":"2026-04-07T01:49:56.147324Z","downstream":{"established":"2026-04-07T01:49:56.147324Z","ipAddress":"::1","port":54833},"upstream":{"established":"2026-04-07T01:49:56.147324Z","ipAddress":"::1","port":8081,"hostname":"localhost"}}}
+```

--- a/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.234885Z.md
+++ b/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.234885Z.md
@@ -1,0 +1,75 @@
+### REQUEST ###
+```
+GET http://localhost:8081/actuator/health HTTP/1.1
+Accept: */*
+Host: localhost:8080
+User-Agent: curl/8.7.1
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/vnd.spring-boot.actuator.v3+json
+Date: Tue\, 07 Apr 2026 01:49:56 GMT
+Expires: 0
+Pragma: no-cache
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "status": "UP",
+  "components": {
+    "db": {
+      "status": "UP",
+      "details": {
+        "database": "PostgreSQL",
+        "validationQuery": "isValid()"
+      }
+    },
+    "diskSpace": {
+      "status": "UP",
+      "details": {
+        "total": 494384795648,
+        "free": 64878305280,
+        "threshold": 10485760,
+        "path": "/Users/kahrens/go/src/github.com/speedscale/agent-factory/.work/run-microsvc-user-service-microsvc-user-service-404/backend/user-service/.",
+        "exists": true
+      }
+    },
+    "livenessState": {
+      "status": "UP"
+    },
+    "ping": {
+      "status": "UP"
+    },
+    "readinessState": {
+      "status": "UP"
+    }
+  },
+  "groups": [
+    "liveness",
+    "readiness"
+  ]
+}
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: b1097458-a772-442b-a353-67d35eb4e943
+ts: 2026-04-07T01:49:56.234885Z
+duration: 12ms
+tags: captureMode=proxy, clientID=1, file=proxymock/recorded-complete/localhost/2026-03-31_22-51-54.141617Z.json, generatorID=1, k8sClusterName=, msgNum=1, proxyProtocol=tcp:http, proxyType=dual, refUuid=8e608f14-5615-4d1e-9298-073add9ebb79, reverseProxyHost=localhost, reverseProxyPort=8080, sequence=889, source=generator
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-04-07T01:49:56.234885Z","l7protocol":"http","duration":12,"tags":{"captureMode":"proxy","clientID":"1","file":"proxymock/recorded-complete/localhost/2026-03-31_22-51-54.141617Z.json","generatorID":"1","k8sClusterName":"","msgNum":"1","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","refUuid":"8e608f14-5615-4d1e-9298-073add9ebb79","reverseProxyHost":"localhost","reverseProxyPort":"8080","sequence":"889","source":"generator"},"uuid":"sQl0WKdyRCujU2fTXrTpQw==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","tech":"JSON","network_address":"localhost:8081","command":"GET","location":"/actuator/health","status":"200 ","http":{"req":{"url":"/actuator/health","uri":"/actuator/health","version":"1.1","method":"GET","host":"localhost"},"res":{"contentType":"application/vnd.spring-boot.actuator.v3+json","statusCode":200,"statusMessage":"200 "}},"tokenList":{"URI:/Users/kahrens/go/src/github.com/speedscale/agent-factory/.work/run-microsvc-user-service-microsvc-user-service-404/backend/user-service/.":{"id":"URI:/Users/kahrens/go/src/github.com/speedscale/agent-factory/.work/run-microsvc-user-service-microsvc-user-service-404/backend/user-service/.","tokens":[{"uuid":"sQl0WKdyRCujU2fTXrTpQw==","token":{"location":"http.res.bodyBase64.components.diskSpace.details.path","pattern":"DATA_PATTERN_URI","replacementValue":"L1VzZXJzL2thaHJlbnMvZ28vc3JjL2dpdGh1Yi5jb20vc3BlZWRzY2FsZS9hZ2VudC1mYWN0b3J5Ly53b3JrL3J1bi1taWNyb3N2Yy11c2VyLXNlcnZpY2UtbWljcm9zdmMtdXNlci1zZXJ2aWNlLTQwNC9iYWNrZW5kL3VzZXItc2VydmljZS8u"}}]},"URI:localhost:8080":{"id":"URI:localhost:8080","tokens":[{"uuid":"sQl0WKdyRCujU2fTXrTpQw==","token":{"location":"http.req.headers.Host[0]","pattern":"DATA_PATTERN_URI","replacementValue":"bG9jYWxob3N0OjgwODA="}}]}},"events":[{"uuid":"288ef393-9e04-4c45-a274-e41f4fd8838e","ts":"2026-04-07T01:49:56.234856Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"80e97117-5a20-46c0-9f62-419314fa3a5f","ts":"2026-04-07T01:49:56.234857Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: localhost","actorType":"GENERATOR"},{"uuid":"567e12a5-d084-46ba-a8dc-990ba90a327d","ts":"2026-04-07T01:49:56.234858Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_hostname(): localhost","actorType":"GENERATOR"},{"uuid":"2d52a9f5-0a80-4e69-88bd-cd79fe02477b","ts":"2026-04-07T01:49:56.234860Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=localhost,requiredSecrets=[]): localhost","actorType":"GENERATOR"},{"uuid":"096d2814-33f2-44fb-a739-723335567bd2","ts":"2026-04-07T01:49:56.234861Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: localhost","actorType":"GENERATOR"},{"uuid":"5794a46c-cd15-4f7e-97a4-98bcf73ccd37","ts":"2026-04-07T01:49:56.234865Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"843b95fb-7a24-47dc-8fbc-a32d37344850","ts":"2026-04-07T01:49:56.234866Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: 8081","actorType":"GENERATOR"},{"uuid":"7ab8c5eb-c663-4cc1-8a44-c00fa85ded63","ts":"2026-04-07T01:49:56.234867Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_port(): 8081","actorType":"GENERATOR"},{"uuid":"16f25818-bf0d-45b8-9def-0074ddb40806","ts":"2026-04-07T01:49:56.234868Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=8081,requiredSecrets=[]): 8081","actorType":"GENERATOR"},{"uuid":"4a3e6ee2-f43c-4039-83ab-26e72b4fc850","ts":"2026-04-07T01:49:56.234868Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: 8081","actorType":"GENERATOR"},{"uuid":"8d69e403-10f4-4412-baad-d4ec086dbf01","ts":"2026-04-07T01:49:56.248507Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])"},{"uuid":"36bc3e58-e7c9-444e-ba62-4f09be5a9e5e","ts":"2026-04-07T01:49:56.248510Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: localhost"},{"uuid":"b2b3e828-2ad6-4c8b-a135-59e668a9bc74","ts":"2026-04-07T01:49:56.248511Z","source":"generator","operation":"transform","message":"[GEN/RES] target_hostname(): localhost"},{"uuid":"75f78dd0-9693-4820-8b7b-c84d4cda477e","ts":"2026-04-07T01:49:56.248513Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=localhost,requiredSecrets=[]): localhost"},{"uuid":"59956f70-3348-405d-8353-cba731659a02","ts":"2026-04-07T01:49:56.248514Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: localhost"},{"uuid":"67f676d6-4504-47a1-bce8-fd1ac48d6a28","ts":"2026-04-07T01:49:56.248520Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])"},{"uuid":"3a4e5578-d71d-4a41-ad5d-c35a54755d5f","ts":"2026-04-07T01:49:56.248521Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: 8081"},{"uuid":"eb646f4f-0775-43e8-81da-3c48e890faaf","ts":"2026-04-07T01:49:56.248522Z","source":"generator","operation":"transform","message":"[GEN/RES] target_port(): 8081"},{"uuid":"8a661bea-ff82-4218-9b94-c5ddc19785fd","ts":"2026-04-07T01:49:56.248523Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=8081,requiredSecrets=[]): 8081"},{"uuid":"8f7fde7a-7d73-4559-b7b3-ba58f0401287","ts":"2026-04-07T01:49:56.248523Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: 8081"}],"netinfo":{"startTime":"2026-04-07T01:49:56.234906Z","downstream":{"established":"2026-04-07T01:49:56.234906Z","ipAddress":"::1","port":54833},"upstream":{"established":"2026-04-07T01:49:56.234906Z","ipAddress":"::1","port":8081,"hostname":"localhost"}}}
+```

--- a/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.249265Z.md
+++ b/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.249265Z.md
@@ -1,0 +1,43 @@
+### REQUEST ###
+```
+GET http://localhost:8081/actuator/health/liveness HTTP/1.1
+Accept: */*
+Host: localhost:8080
+User-Agent: curl/8.7.1
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/vnd.spring-boot.actuator.v3+json
+Date: Tue\, 07 Apr 2026 01:49:56 GMT
+Expires: 0
+Pragma: no-cache
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "status": "UP"
+}
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: 4f8c3a08-cceb-4bb0-a3d7-92658878c70b
+ts: 2026-04-07T01:49:56.249265Z
+duration: 1ms
+tags: captureMode=proxy, clientID=1, file=proxymock/recorded-complete/localhost/2026-03-31_22-51-54.172195Z.json, generatorID=1, k8sClusterName=, msgNum=2, proxyProtocol=tcp:http, proxyType=dual, refUuid=d58a335a-c475-4e97-84c7-bb842a1fbd48, reverseProxyHost=localhost, reverseProxyPort=8080, sequence=891, source=generator
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-04-07T01:49:56.249265Z","l7protocol":"http","duration":1,"tags":{"captureMode":"proxy","clientID":"1","file":"proxymock/recorded-complete/localhost/2026-03-31_22-51-54.172195Z.json","generatorID":"1","k8sClusterName":"","msgNum":"2","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","refUuid":"d58a335a-c475-4e97-84c7-bb842a1fbd48","reverseProxyHost":"localhost","reverseProxyPort":"8080","sequence":"891","source":"generator"},"uuid":"T4w6CMzrS7Cj15JliHjHCw==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","tech":"JSON","network_address":"localhost:8081","command":"GET","location":"/actuator/health/liveness","status":"200 ","http":{"req":{"url":"/actuator/health/liveness","uri":"/actuator/health/liveness","version":"1.1","method":"GET","host":"localhost"},"res":{"contentType":"application/vnd.spring-boot.actuator.v3+json","statusCode":200,"statusMessage":"200 "}},"tokenList":{"URI:localhost:8080":{"id":"URI:localhost:8080","tokens":[{"uuid":"T4w6CMzrS7Cj15JliHjHCw==","token":{"location":"http.req.headers.Host[0]","pattern":"DATA_PATTERN_URI","replacementValue":"bG9jYWxob3N0OjgwODA="}}]}},"events":[{"uuid":"a4176cb3-6b85-4a1e-bc4e-bb3330fbc431","ts":"2026-04-07T01:49:56.249242Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"6b332838-a17a-417b-bcd7-851f9f0accdf","ts":"2026-04-07T01:49:56.249243Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: localhost","actorType":"GENERATOR"},{"uuid":"4f6b8850-5cb1-4713-93f0-8af2cdd5b24b","ts":"2026-04-07T01:49:56.249244Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_hostname(): localhost","actorType":"GENERATOR"},{"uuid":"f219dbfa-7909-4a1b-ac28-02fd8c47bbea","ts":"2026-04-07T01:49:56.249245Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=localhost,requiredSecrets=[]): localhost","actorType":"GENERATOR"},{"uuid":"fd5166e7-bb6d-43dc-b0d5-ed2c50c7262d","ts":"2026-04-07T01:49:56.249246Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: localhost","actorType":"GENERATOR"},{"uuid":"e5d56008-0e8b-417b-87b5-7354cc3a93f2","ts":"2026-04-07T01:49:56.249250Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"9b6876ff-6447-437b-af71-c68c0b1884aa","ts":"2026-04-07T01:49:56.249251Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: 8081","actorType":"GENERATOR"},{"uuid":"b44d7be4-0089-4f18-929b-41c948dd3208","ts":"2026-04-07T01:49:56.249251Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_port(): 8081","actorType":"GENERATOR"},{"uuid":"4cca2a6d-37ef-4d64-949b-e97064215954","ts":"2026-04-07T01:49:56.249253Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=8081,requiredSecrets=[]): 8081","actorType":"GENERATOR"},{"uuid":"b814ca40-f849-44cb-9088-1823e2cb0d02","ts":"2026-04-07T01:49:56.249254Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: 8081","actorType":"GENERATOR"},{"uuid":"7d1242da-21a1-44a9-8479-f3c0c75f4b9e","ts":"2026-04-07T01:49:56.251684Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])"},{"uuid":"65e8282b-4d42-4a08-9a99-b79b8b1a3a09","ts":"2026-04-07T01:49:56.251687Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: localhost"},{"uuid":"c99d90c3-a196-4c37-9b54-aa85d0cb7c7d","ts":"2026-04-07T01:49:56.251688Z","source":"generator","operation":"transform","message":"[GEN/RES] target_hostname(): localhost"},{"uuid":"e89ec05b-48a8-44dc-a8d2-40e768642313","ts":"2026-04-07T01:49:56.251691Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=localhost,requiredSecrets=[]): localhost"},{"uuid":"b8f3ed0b-f04c-4a65-b1ee-7bfd4b15add6","ts":"2026-04-07T01:49:56.251692Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: localhost"},{"uuid":"bcaf3794-9749-448d-9cdb-2828012f868f","ts":"2026-04-07T01:49:56.251698Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])"},{"uuid":"353b85dc-222b-4a63-8aa2-ad9050a0e00a","ts":"2026-04-07T01:49:56.251699Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: 8081"},{"uuid":"17999097-b3e4-4763-80a4-680beded486e","ts":"2026-04-07T01:49:56.251700Z","source":"generator","operation":"transform","message":"[GEN/RES] target_port(): 8081"},{"uuid":"46c8ec6e-b525-4eca-8be5-2841d30906b2","ts":"2026-04-07T01:49:56.251701Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=8081,requiredSecrets=[]): 8081"},{"uuid":"c3755a40-05e5-4f26-945c-181df194cd1c","ts":"2026-04-07T01:49:56.251701Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: 8081"}],"netinfo":{"startTime":"2026-04-07T01:49:56.249281Z","downstream":{"established":"2026-04-07T01:49:56.249281Z","ipAddress":"::1","port":54833},"upstream":{"established":"2026-04-07T01:49:56.249281Z","ipAddress":"::1","port":8081,"hostname":"localhost"}}}
+```

--- a/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.252247Z.md
+++ b/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.252247Z.md
@@ -1,0 +1,43 @@
+### REQUEST ###
+```
+GET http://localhost:8081/actuator/health/readiness HTTP/1.1
+Accept: */*
+Host: localhost:8080
+User-Agent: curl/8.7.1
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/vnd.spring-boot.actuator.v3+json
+Date: Tue\, 07 Apr 2026 01:49:56 GMT
+Expires: 0
+Pragma: no-cache
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "status": "UP"
+}
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: 9c98eff9-6fe5-4a39-84f4-b0bc99727f8a
+ts: 2026-04-07T01:49:56.252247Z
+duration: 1ms
+tags: captureMode=proxy, clientID=1, file=proxymock/recorded-complete/localhost/2026-03-31_22-51-54.187896Z.json, generatorID=1, k8sClusterName=, msgNum=3, proxyProtocol=tcp:http, proxyType=dual, refUuid=77202fe7-b8ef-426b-ab5a-ddccd2023766, reverseProxyHost=localhost, reverseProxyPort=8080, sequence=893, source=generator
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-04-07T01:49:56.252247Z","l7protocol":"http","duration":1,"tags":{"captureMode":"proxy","clientID":"1","file":"proxymock/recorded-complete/localhost/2026-03-31_22-51-54.187896Z.json","generatorID":"1","k8sClusterName":"","msgNum":"3","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","refUuid":"77202fe7-b8ef-426b-ab5a-ddccd2023766","reverseProxyHost":"localhost","reverseProxyPort":"8080","sequence":"893","source":"generator"},"uuid":"nJjv+W/lSjmE9LC8mXJ/ig==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","tech":"JSON","network_address":"localhost:8081","command":"GET","location":"/actuator/health/readiness","status":"200 ","http":{"req":{"url":"/actuator/health/readiness","uri":"/actuator/health/readiness","version":"1.1","method":"GET","host":"localhost"},"res":{"contentType":"application/vnd.spring-boot.actuator.v3+json","statusCode":200,"statusMessage":"200 "}},"tokenList":{"URI:localhost:8080":{"id":"URI:localhost:8080","tokens":[{"uuid":"nJjv+W/lSjmE9LC8mXJ/ig==","token":{"location":"http.req.headers.Host[0]","pattern":"DATA_PATTERN_URI","replacementValue":"bG9jYWxob3N0OjgwODA="}}]}},"events":[{"uuid":"83e3d3c3-3ca0-4630-8b0a-8590f088c095","ts":"2026-04-07T01:49:56.252226Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"95cfa58f-4163-46c7-9169-3426ad37e313","ts":"2026-04-07T01:49:56.252228Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: localhost","actorType":"GENERATOR"},{"uuid":"6b2428a1-9955-4ba6-8377-f7d4c68a821f","ts":"2026-04-07T01:49:56.252229Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_hostname(): localhost","actorType":"GENERATOR"},{"uuid":"916231a7-9043-4013-9cec-e099a58f14a4","ts":"2026-04-07T01:49:56.252230Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=localhost,requiredSecrets=[]): localhost","actorType":"GENERATOR"},{"uuid":"9738db9c-3826-4204-89b7-edcc4b2ecf75","ts":"2026-04-07T01:49:56.252231Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: localhost","actorType":"GENERATOR"},{"uuid":"9c427011-a5fe-4cc0-a402-3b083ef5f685","ts":"2026-04-07T01:49:56.252234Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"df652ae7-132e-4876-8f15-67b0af4685f7","ts":"2026-04-07T01:49:56.252236Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: 8081","actorType":"GENERATOR"},{"uuid":"36fe4f73-8f62-446f-816b-d10ca332dcd9","ts":"2026-04-07T01:49:56.252237Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_port(): 8081","actorType":"GENERATOR"},{"uuid":"94a5f7ab-f5fe-4f48-b0ca-d48c22969609","ts":"2026-04-07T01:49:56.252238Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=8081,requiredSecrets=[]): 8081","actorType":"GENERATOR"},{"uuid":"5b550a96-9276-4ac7-9a9f-fc557c2146c3","ts":"2026-04-07T01:49:56.252238Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: 8081","actorType":"GENERATOR"},{"uuid":"25e408a3-c981-4549-af7f-8938d5d68c75","ts":"2026-04-07T01:49:56.254262Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])"},{"uuid":"5d9459f0-abda-4a34-a8ec-4f70160faf1d","ts":"2026-04-07T01:49:56.254264Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: localhost"},{"uuid":"b96c352f-b2e8-43a2-947e-f83b4704d94e","ts":"2026-04-07T01:49:56.254265Z","source":"generator","operation":"transform","message":"[GEN/RES] target_hostname(): localhost"},{"uuid":"470fa136-0291-42bc-bcd4-c7ba958750de","ts":"2026-04-07T01:49:56.254267Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=localhost,requiredSecrets=[]): localhost"},{"uuid":"2fa73703-a4e3-4ae7-bf97-114e7790ce3b","ts":"2026-04-07T01:49:56.254267Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: localhost"},{"uuid":"aa799986-87f7-48af-8748-93dce25f75f3","ts":"2026-04-07T01:49:56.254274Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])"},{"uuid":"9373874b-72d7-4216-b6a0-5b33265ae262","ts":"2026-04-07T01:49:56.254275Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: 8081"},{"uuid":"cba4f9d2-abc1-4f1f-9290-ff8a5ca8e08a","ts":"2026-04-07T01:49:56.254276Z","source":"generator","operation":"transform","message":"[GEN/RES] target_port(): 8081"},{"uuid":"bcadc48d-118c-44af-8b4b-5642a4c199a5","ts":"2026-04-07T01:49:56.254277Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=8081,requiredSecrets=[]): 8081"},{"uuid":"f302055e-7706-4909-acdc-33687de3577d","ts":"2026-04-07T01:49:56.254278Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: 8081"}],"netinfo":{"startTime":"2026-04-07T01:49:56.252261Z","downstream":{"established":"2026-04-07T01:49:56.252261Z","ipAddress":"::1","port":54833},"upstream":{"established":"2026-04-07T01:49:56.252261Z","ipAddress":"::1","port":8081,"hostname":"localhost"}}}
+```

--- a/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.254741Z.md
+++ b/backend/user-service/proxymock/results/replayed-2026-04-07_01-49-55.006709Z/localhost/2026-04-07_01-49-56.254741Z.md
@@ -1,0 +1,45 @@
+### REQUEST ###
+```
+GET http://localhost:8081/api/users/check-username?username=recordprobe HTTP/1.1
+Accept: */*
+Host: localhost:8080
+User-Agent: curl/8.7.1
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Date: Tue\, 07 Apr 2026 01:49:56 GMT
+Expires: 0
+Pragma: no-cache
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "success": true,
+  "available": true,
+  "message": "Username is available"
+}
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: 39791af6-848b-4b2b-9695-30f8f9ab89aa
+ts: 2026-04-07T01:49:56.254741Z
+duration: 40ms
+tags: captureMode=proxy, clientID=1, file=proxymock/recorded-complete/localhost/2026-03-31_22-51-54.203676Z.json, generatorID=1, k8sClusterName=, msgNum=4, proxyProtocol=tcp:http, proxyType=dual, refUuid=97b8db9d-8db8-4636-b494-b59bd2ec24bd, reverseProxyHost=localhost, reverseProxyPort=8080, sequence=915, source=generator
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-04-07T01:49:56.254741Z","l7protocol":"http","duration":40,"tags":{"captureMode":"proxy","clientID":"1","file":"proxymock/recorded-complete/localhost/2026-03-31_22-51-54.203676Z.json","generatorID":"1","k8sClusterName":"","msgNum":"4","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","refUuid":"97b8db9d-8db8-4636-b494-b59bd2ec24bd","reverseProxyHost":"localhost","reverseProxyPort":"8080","sequence":"915","source":"generator"},"uuid":"OXka9oSLSyuWlTD4+auJqg==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","tech":"JSON","network_address":"localhost:8081","command":"GET","location":"/api/users/check-username","status":"200 ","http":{"req":{"url":"/api/users/check-username","uri":"/api/users/check-username?username=recordprobe","version":"1.1","method":"GET","host":"localhost"},"res":{"contentType":"application/json","statusCode":200,"statusMessage":"200 "}},"tokenList":{"URI:localhost:8080":{"id":"URI:localhost:8080","tokens":[{"uuid":"OXka9oSLSyuWlTD4+auJqg==","token":{"location":"http.req.headers.Host[0]","pattern":"DATA_PATTERN_URI","replacementValue":"bG9jYWxob3N0OjgwODA="}}]}},"events":[{"uuid":"f733e7ea-8bc6-42be-ad4d-bd21ed346719","ts":"2026-04-07T01:49:56.254717Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"ecff191e-a0df-4bfc-bd61-aa3a7f660d5a","ts":"2026-04-07T01:49:56.254719Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: localhost","actorType":"GENERATOR"},{"uuid":"8ebe1f10-0142-4c4a-9930-15c9c5f8e614","ts":"2026-04-07T01:49:56.254720Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_hostname(): localhost","actorType":"GENERATOR"},{"uuid":"dd7c4a9f-e68c-4d68-98af-6f43591cd398","ts":"2026-04-07T01:49:56.254721Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=localhost,requiredSecrets=[]): localhost","actorType":"GENERATOR"},{"uuid":"f34f0494-fe13-4160-91bf-8365abddf8ce","ts":"2026-04-07T01:49:56.254722Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: localhost","actorType":"GENERATOR"},{"uuid":"e1bde502-1aaa-435e-b4ff-033bab0981c6","ts":"2026-04-07T01:49:56.254725Z","source":"generator","operation":"transform","message":"[GEN/REQ] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])","actorType":"GENERATOR"},{"uuid":"b73ac070-6240-4721-9773-6934c1e2c00a","ts":"2026-04-07T01:49:56.254726Z","source":"generator","operation":"transform","message":"[GEN/REQ] extracted value: 8081","actorType":"GENERATOR"},{"uuid":"6b7bf4d4-c634-4b53-ad36-057875137cbb","ts":"2026-04-07T01:49:56.254727Z","source":"generator","operation":"transform","message":"[GEN/REQ] target_port(): 8081","actorType":"GENERATOR"},{"uuid":"3f5c7482-950a-44eb-8365-216dc7d911dd","ts":"2026-04-07T01:49:56.254728Z","source":"generator","operation":"transform","message":"[GEN/REQ] constant(new=8081,requiredSecrets=[]): 8081","actorType":"GENERATOR"},{"uuid":"40585391-b79b-4ee8-b485-39a5cffb88d6","ts":"2026-04-07T01:49:56.254729Z","source":"generator","operation":"transform","message":"[GEN/REQ] final value: 8081","actorType":"GENERATOR"},{"uuid":"c4a588c7-e4a3-46ad-bf99-a697f488eb62","ts":"2026-04-07T01:49:56.296247Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_hostname() | constant(new=localhost,requiredSecrets=[])"},{"uuid":"36afd52a-0da6-463e-aca7-89a8ecdc02af","ts":"2026-04-07T01:49:56.296251Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: localhost"},{"uuid":"3ba56c1f-6f66-42fd-b587-0feea51b07d6","ts":"2026-04-07T01:49:56.296251Z","source":"generator","operation":"transform","message":"[GEN/RES] target_hostname(): localhost"},{"uuid":"5026a9c7-f115-40ea-b476-3a6383d05e15","ts":"2026-04-07T01:49:56.296254Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=localhost,requiredSecrets=[]): localhost"},{"uuid":"5aa7578e-1e5e-4d89-8a2b-5022ef4eeb08","ts":"2026-04-07T01:49:56.296255Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: localhost"},{"uuid":"0a592992-5246-439a-91b6-14449971b4a0","ts":"2026-04-07T01:49:56.296261Z","source":"generator","operation":"transform","message":"[GEN/RES] Applying: (service IS \"my\\-app\" AND networkaddr IS \"localhost:8080\") | target_port() | constant(new=8081,requiredSecrets=[])"},{"uuid":"a148c233-25c5-4665-9b13-ffd98936cb06","ts":"2026-04-07T01:49:56.296262Z","source":"generator","operation":"transform","message":"[GEN/RES] extracted value: 8081"},{"uuid":"203e463b-19cc-494d-9252-49ac7d2bea15","ts":"2026-04-07T01:49:56.296263Z","source":"generator","operation":"transform","message":"[GEN/RES] target_port(): 8081"},{"uuid":"44b7a0a0-1c2d-4b04-bcdf-55797e592a7c","ts":"2026-04-07T01:49:56.296264Z","source":"generator","operation":"transform","message":"[GEN/RES] constant(new=8081,requiredSecrets=[]): 8081"},{"uuid":"d3cb3d30-d738-48ee-8f55-df97c0a5177d","ts":"2026-04-07T01:49:56.296265Z","source":"generator","operation":"transform","message":"[GEN/RES] final value: 8081"}],"netinfo":{"startTime":"2026-04-07T01:49:56.254752Z","downstream":{"established":"2026-04-07T01:49:56.254752Z","ipAddress":"::1","port":54833},"upstream":{"established":"2026-04-07T01:49:56.254752Z","ipAddress":"::1","port":8081,"hostname":"localhost"}}}
+```


### PR DESCRIPTION
## Summary
- automated run-to-PR output for run-microsvc-user-service-microsvc-user-service-404
- issue: Microsvc user service returns 500 instead of 404 for a missing user

## Evidence
- run artifact: artifacts/run-microsvc-user-service-microsvc-user-service-404/run.json
- triage artifact: artifacts/run-microsvc-user-service-microsvc-user-service-404/triage.json
- patch artifact: artifacts/run-microsvc-user-service-microsvc-user-service-404/patch.diff
- validation artifact: artifacts/run-microsvc-user-service-microsvc-user-service-404/validation.log
- result artifact: artifacts/run-microsvc-user-service-microsvc-user-service-404/result.json