### PR TITLE
Fix: set Speedscale overlay sidecar injection to true

### DIFF
--- a/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
@@ -4,6 +4,6 @@ metadata:
   name: accounts-service
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
+    sidecar.speedscale.com/inject: "true"
     sidecar.speedscale.com/tls-out: "true"
     sidecar.speedscale.com/tls-java-tool-options: "true"

--- a/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
+++ b/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
@@ -4,6 +4,6 @@ metadata:
   name: api-gateway
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
+    sidecar.speedscale.com/inject: "true"
     sidecar.speedscale.com/tls-out: "true"
     sidecar.speedscale.com/tls-java-tool-options: "true"

--- a/kubernetes/overlays/speedscale/frontend-annotations.yaml
+++ b/kubernetes/overlays/speedscale/frontend-annotations.yaml
@@ -4,5 +4,5 @@ metadata:
   name: frontend
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
+    sidecar.speedscale.com/inject: "true"
     sidecar.speedscale.com/tls-out: "true"

--- a/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
+++ b/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: simulation-client
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
+    sidecar.speedscale.com/inject: "true"
     speedscale.com/service-name: "simulation-client"
 spec:
   template:

--- a/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
@@ -4,6 +4,6 @@ metadata:
   name: transactions-service
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
+    sidecar.speedscale.com/inject: "true"
     sidecar.speedscale.com/tls-out: "true"
     sidecar.speedscale.com/tls-java-tool-options: "true"

--- a/kubernetes/overlays/speedscale/user-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/user-service-annotations.yaml
@@ -4,6 +4,6 @@ metadata:
   name: user-service
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
+    sidecar.speedscale.com/inject: "true"
     sidecar.speedscale.com/tls-out: "true"
     sidecar.speedscale.com/tls-java-tool-options: "true"


### PR DESCRIPTION
## Summary
- change Speedscale overlay deployment annotations to sidecar.speedscale.com/inject: "true" for banking-app workloads
- fix Argo reconciliation behavior so deployment annotations no longer revert sidecar injection to false
- links issue #66

## Changed Files
- kubernetes/overlays/speedscale/accounts-service-annotations.yaml
- kubernetes/overlays/speedscale/api-gateway-annotations.yaml
- kubernetes/overlays/speedscale/frontend-annotations.yaml
- kubernetes/overlays/speedscale/simulation-client-annotations.yaml
- kubernetes/overlays/speedscale/transactions-service-annotations.yaml
- kubernetes/overlays/speedscale/user-service-annotations.yaml