### PR TITLE
ci: auto-sync frontend/package.json version from VERSION on master merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,20 +178,21 @@ jobs:
         echo "simple_tag=$SIMPLE_TAG" >> $GITHUB_OUTPUT
         echo "Simple tag: $SIMPLE_TAG"
     
-    - name: Update Kubernetes manifests
+    - name: Update Kubernetes manifests and frontend version
       run: |
         make update-k8s-version
+        make update-frontend-version
         if [ -n "$(git diff)" ]; then
-          echo "Kubernetes manifests updated with version ${{ steps.version.outputs.simple_tag }}"
+          echo "Manifests and package.json updated with version ${{ steps.version.outputs.simple_tag }}"
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add kubernetes/base/deployments/
-          git commit -m "Update K8s manifests to version ${{ steps.version.outputs.simple_tag }}
+          git add kubernetes/base/deployments/ frontend/package.json simulation-client/package.json
+          git commit -m "CI: sync versions to ${{ steps.version.outputs.simple_tag }}
 
           Automated by GitHub Actions CI workflow."
           git push
         else
-          echo "No changes to Kubernetes manifests"
+          echo "No changes to manifests or package versions"
         fi
 
   e2e-test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,32 @@ This project follows a phased implementation approach. Each phase must be comple
 
 ## Version Bump Policy
 
-- CI pipeline enforcement is the source of truth for service version bumps.
-- For pull requests, if code changes under `backend/<service>/`, that service must bump the project `<version>` in `backend/<service>/pom.xml`.
-- Docs-only or infra-only changes can skip a service version bump.
-- Agent behavior should attempt version bumps, but CI is the final gate.
+The project uses a two-tier versioning model:
+
+**Global version** — stored in the root `VERSION` file (e.g. `1.4.1`). This is the canonical source of truth for Docker image tags and all non-Java package versions.
+
+**Per-service version** — each Java backend service tracks its own `<version>` in `backend/<service>/pom.xml`.
+
+### Rules for agents and developers
+
+| File | Who bumps it? | When? |
+|------|--------------|-------|
+| `backend/<service>/pom.xml` | Agent / developer | Required in any PR that modifies code under `backend/<service>/` |
+| `VERSION` | Agent / developer | When a global release version change is needed (e.g. a minor or major bump) |
+| `frontend/package.json` | **CI only — do not touch** | Auto-synced from `VERSION` on every merge to `master` |
+| `simulation-client/package.json` | **CI only — do not touch** | Auto-synced from `VERSION` on every merge to `master` |
+| `kubernetes/base/deployments/*.yaml` | **CI only — do not touch** | Auto-updated from `VERSION` on every merge to `master` |
+
+### How CI handles versioning (on merge to `master`)
+
+The `update-k8s-manifests` CI job runs `make update-frontend-version` followed by `make update-k8s-version` and commits any resulting changes back to the branch. This is implemented via:
+
+- `scripts/version.sh update-frontend` — syncs `frontend/package.json` and `simulation-client/package.json` to `VERSION`
+- `scripts/version.sh update-k8s` — updates image tags in `kubernetes/base/deployments/`
+
+**Do NOT manually bump `frontend/package.json` or `simulation-client/package.json`.** Doing so creates merge conflicts across concurrent branches because multiple agents will all bump from the same base version independently. Let CI handle it.
+
+Docs-only or infra-only changes can skip a `pom.xml` version bump. CI is the final enforcement gate.
 
 ## Current Status
 

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,9 @@ version-set:
 	fi
 	@./scripts/version.sh set $(VERSION)
 
+update-frontend-version:
+	@./scripts/version.sh update-frontend
+
 update-k8s-version:
 	@./scripts/version.sh update-k8s
 
@@ -286,6 +289,7 @@ help:
 	@echo "  version-info       - Show version information"
 	@echo "  version-bump       - Bump version (BUMP_TYPE=<patch|minor|major>)"
 	@echo "  version-set        - Set version (VERSION=<version>)"
+	@echo "  update-frontend-version - Sync frontend/simulation-client package.json version from VERSION file"
 	@echo "  update-k8s-version - Update Kubernetes manifests with current version"
 	@echo ""
 	@echo "Utilities:"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/scripts/check_service_version_bumps.py
+++ b/scripts/check_service_version_bumps.py
@@ -67,6 +67,7 @@ def merge_base(commit_a, commit_b):
     return run_git(["merge-base", commit_a, commit_b]).strip()
 
 
+
 def main():
     if len(sys.argv) != 3:
         print(

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -177,6 +177,21 @@ validate_versions() {
     fi
 }
 
+# Update only frontend and simulation-client package.json files (not backend pom.xml)
+update_frontend_versions() {
+    local version=$(get_version)
+    echo "Updating frontend package.json files with version: $version"
+
+    for service in "${FRONTEND_SERVICES[@]}" "${SIMULATION_SERVICES[@]}"; do
+        local package_file="${service}/package.json"
+        if [ -f "$package_file" ]; then
+            sed -i.bak "s|\"version\": \"[0-9]*\.[0-9]*\.[0-9]*\"|\"version\": \"${version}\"|" "$package_file"
+            echo "Updated $package_file to version $version"
+            rm -f "${package_file}.bak"
+        fi
+    done
+}
+
 # Update Kubernetes manifests with the simple version tag
 update_k8s_manifests() {
     local tag=$(get_image_tag) # Explicitly use the simple tag
@@ -248,6 +263,9 @@ case "${1:-help}" in
         fi
         get_image_name "$2"
         ;;
+    "update-frontend")
+        update_frontend_versions
+        ;;
     "update-k8s")
         update_k8s_manifests
         ;;
@@ -276,6 +294,7 @@ case "${1:-help}" in
         echo "  tag                    - Get simple image tag (e.g., v1.2.3)"
         echo "  tag-sha                - Get image tag with git hash (e.g., v1.2.3-a1b2c3d)"
         echo "  image <service>        - Get full image name for service with SHA"
+        echo "  update-frontend        - Update frontend/simulation-client package.json with current version"
         echo "  update-k8s             - Update Kubernetes manifests with simple version"
         echo "  update-all             - Update all project files (pom.xml, package.json) with current version"
         echo "  validate               - Validate that all project files have consistent versions"
@@ -290,6 +309,7 @@ case "${1:-help}" in
         echo "  $0 tag                 # Get simple tag"
         echo "  $0 tag-sha             # Get tag with SHA"
         echo "  $0 image api-gateway   # Get image name for api-gateway"
+        echo "  $0 update-frontend     # Update frontend/simulation-client package.json"
         echo "  $0 update-k8s          # Update K8s manifests with simple version"
         echo "  $0 update-all          # Update all project files with current version"
         echo "  $0 validate            # Check version consistency"

--- a/simulation-client/package.json
+++ b/simulation-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banking-simulation-client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Continuous user simulation client for banking application",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Moves `frontend/package.json` and `simulation-client/package.json` version bumps from agents/developers to the CI pipeline, eliminating the recurring merge conflicts caused by multiple branches independently bumping the same version field from the same base.
- Adds `scripts/version.sh update-frontend` and `make update-frontend-version` for syncing those files from the root `VERSION` file.
- Extends the existing `update-k8s-manifests` CI job (which already had write access and ran only on master) to also sync the package.json versions in the same auto-commit.
- Documents the full two-tier versioning model in `AGENTS.md` so future agents know exactly which files they should and should not touch.

## What changed

| File | Change |
|------|--------|
| `scripts/version.sh` | New `update-frontend` command — syncs only `frontend/` and `simulation-client/` package.json from `VERSION` |
| `Makefile` | New `update-frontend-version` target |
| `.github/workflows/ci.yml` | `update-k8s-manifests` job now also runs `make update-frontend-version` and commits package.json changes |
| `AGENTS.md` | Full versioning policy table; explicit prohibition on manual package.json bumps |
| `frontend/package.json` | Synced to `1.4.1` (current `VERSION`) |
| `simulation-client/package.json` | Synced to `1.4.1` |

## Test plan

- [ ] Verify the `update-k8s-manifests` job runs on the next push to `master` and produces a commit that updates `frontend/package.json` if it is out of sync with `VERSION`
- [ ] Confirm no manual `frontend/package.json` bumps appear in subsequent agent PRs

Made with [Cursor](https://cursor.com)