### PR TITLE
feat: Speedscale+Istio overlay with banking- workload prefixes

### DIFF
--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -8,14 +8,14 @@ metadata:
     app.kubernetes.io/component: config
 data:
   # Database configuration
-  DB_HOST: "postgres"
+  DB_HOST: "banking-postgres"
   DB_PORT: "5432"
   DB_NAME: "banking_app"
   
   # Service URLs (for inter-service communication)
-  USER_SERVICE_URL: "http://user-service:80"
-  ACCOUNTS_SERVICE_URL: "http://accounts-service:80"
-  TRANSACTIONS_SERVICE_URL: "http://transactions-service:80"
+  USER_SERVICE_URL: "http://banking-user:80"
+  ACCOUNTS_SERVICE_URL: "http://banking-accounts:80"
+  TRANSACTIONS_SERVICE_URL: "http://banking-transactions:80"
   
   # Spring profiles
   SPRING_PROFILES_ACTIVE: "docker"
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: user-service-config
+  name: banking-user-config
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -64,7 +64,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: accounts-service-config
+  name: banking-accounts-config
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -86,7 +86,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: transactions-service-config
+  name: banking-transactions-config
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -108,7 +108,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: api-gateway-config
+  name: banking-gateway-config
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -130,7 +130,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: frontend-config
+  name: banking-frontend-config
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app

--- a/kubernetes/base/configmaps/app-secrets.yaml
+++ b/kubernetes/base/configmaps/app-secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: postgres-secret
+  name: banking-postgres-secret
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -13,7 +13,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: jwt-secret
+  name: banking-jwt-secret
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -25,7 +25,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: db-credentials
+  name: banking-db-credentials
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app

--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: simulation-client-config
+  name: banking-sim-config
   namespace: banking-app
   labels:
     app: simulation-client
@@ -13,7 +13,7 @@ data:
   LOG_FORMAT: "json"
   
   # Target application settings
-  TARGET_BASE_URL: "http://frontend:80"
+  TARGET_BASE_URL: "http://banking-frontend:80"
   REQUEST_TIMEOUT: "10000"
   
   # Simulation settings

--- a/kubernetes/base/configmaps/simulation-client-secret.yaml
+++ b/kubernetes/base/configmaps/simulation-client-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: simulation-client-secret
+  name: banking-sim-secret
   namespace: banking-app
   labels:
     app: simulation-client

--- a/kubernetes/base/database/postgres-configmap.yaml
+++ b/kubernetes/base/database/postgres-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: postgres-init-script
+  name: banking-postgres-init
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app

--- a/kubernetes/base/database/postgres-deployment.yaml
+++ b/kubernetes/base/database/postgres-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgres
+  name: banking-postgres
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -10,13 +10,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: postgres
+      app: banking-postgres
       app.kubernetes.io/name: banking-app
       app.kubernetes.io/component: database
   template:
     metadata:
       labels:
-        app: postgres
+        app: banking-postgres
         app.kubernetes.io/name: banking-app
         app.kubernetes.io/component: database
     spec:
@@ -35,7 +35,7 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: banking-postgres-secret
               key: password
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
@@ -75,7 +75,7 @@ spec:
       volumes:
       - name: postgres-storage
         persistentVolumeClaim:
-          claimName: postgres-pvc
+          claimName: banking-postgres-pvc
       - name: postgres-init
         configMap:
-          name: postgres-init-script
+          name: banking-postgres-init

--- a/kubernetes/base/database/postgres-pvc.yaml
+++ b/kubernetes/base/database/postgres-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: postgres-pvc
+  name: banking-postgres-pvc
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app

--- a/kubernetes/base/database/postgres-service.yaml
+++ b/kubernetes/base/database/postgres-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres
+  name: banking-postgres
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     name: postgres
   selector:
-    app: postgres
+    app: banking-postgres
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: database

--- a/kubernetes/base/deployments/accounts-service-deployment.yaml
+++ b/kubernetes/base/deployments/accounts-service-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: accounts-service
+  name: banking-accounts
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -11,13 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: accounts-service
+      app: banking-accounts
       app.kubernetes.io/name: banking-app
       app.kubernetes.io/component: microservice
   template:
     metadata:
       labels:
-        app: accounts-service
+        app: banking-accounts
         app.kubernetes.io/name: banking-app
         app.kubernetes.io/component: microservice
         app.kubernetes.io/service: accounts-service
@@ -36,12 +36,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: db-credentials
+              name: banking-db-credentials
               key: accounts-service-password
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
-              name: jwt-secret
+              name: banking-jwt-secret
               key: secret
         - name: JAVA_OPTS
           value: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=32m -XX:MaxDirectMemorySize=16m -XX:+UseSerialGC -XX:+UseStringDeduplication -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dspring.main.lazy-initialization=true"
@@ -49,7 +49,7 @@ spec:
         - configMapRef:
             name: app-config
         - configMapRef:
-            name: accounts-service-config
+            name: banking-accounts-config
         resources:
           requests:
             memory: "256Mi"
@@ -84,4 +84,4 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine
-        command: ['sh', '-c', 'echo "[accounts-service] Waiting for PostgreSQL..."; until pg_isready -h postgres -p 5432 -q; do sleep 1; done; echo "[accounts-service] PostgreSQL ready!"']
+        command: ['sh', '-c', 'echo "[accounts-service] Waiting for PostgreSQL..."; until pg_isready -h banking-postgres -p 5432 -q; do sleep 1; done; echo "[accounts-service] PostgreSQL ready!"']

--- a/kubernetes/base/deployments/api-gateway-deployment.yaml
+++ b/kubernetes/base/deployments/api-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: api-gateway
+  name: banking-gateway
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -11,13 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: api-gateway
+      app: banking-gateway
       app.kubernetes.io/name: banking-app
       app.kubernetes.io/component: gateway
   template:
     metadata:
       labels:
-        app: api-gateway
+        app: banking-gateway
         app.kubernetes.io/name: banking-app
         app.kubernetes.io/component: gateway
         app.kubernetes.io/service: api-gateway
@@ -36,7 +36,7 @@ spec:
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
-              name: jwt-secret
+              name: banking-jwt-secret
               key: secret
         - name: JAVA_OPTS
           value: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=32m -XX:MaxDirectMemorySize=16m -XX:+UseSerialGC -XX:+UseStringDeduplication -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dspring.main.lazy-initialization=true"
@@ -44,7 +44,7 @@ spec:
         - configMapRef:
             name: app-config
         - configMapRef:
-            name: api-gateway-config
+            name: banking-gateway-config
         resources:
           requests:
             memory: "256Mi"
@@ -79,4 +79,4 @@ spec:
       initContainers:
       - name: wait-for-services
         image: busybox:1.35
-        command: ['sh', '-c', 'echo "[api-gateway] Waiting for microservices..."; services="user-service:80 accounts-service:80 transactions-service:80"; for service in $services; do while ! nc -z ${service%:*} ${service#*:}; do echo "[api-gateway] Waiting for $service..."; sleep 1; done; echo "[api-gateway] ✓ $service ready"; done; echo "[api-gateway] All services ready!"']
+        command: ['sh', '-c', 'echo "[api-gateway] Waiting for microservices..."; services="banking-user:80 banking-accounts:80 banking-transactions:80"; for service in $services; do while ! nc -z ${service%:*} ${service#*:}; do echo "[api-gateway] Waiting for $service..."; sleep 1; done; echo "[api-gateway] ✓ $service ready"; done; echo "[api-gateway] All services ready!"']

--- a/kubernetes/base/deployments/frontend-deployment.yaml
+++ b/kubernetes/base/deployments/frontend-deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: frontend
+  name: banking-frontend
   namespace: banking-app
   labels:
-    app: frontend
+    app: banking-frontend
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: frontend
     app.kubernetes.io/managed-by: kustomize
@@ -14,11 +14,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: frontend
+      app: banking-frontend
   template:
     metadata:
       labels:
-        app: frontend
+        app: banking-frontend
         app.kubernetes.io/name: banking-app
         app.kubernetes.io/component: frontend
         app.kubernetes.io/service: frontend
@@ -33,7 +33,7 @@ spec:
           name: http
         envFrom:
         - configMapRef:
-            name: frontend-config
+            name: banking-frontend-config
         resources:
           requests:
             memory: "128Mi"

--- a/kubernetes/base/deployments/simulation-client-deployment.yaml
+++ b/kubernetes/base/deployments/simulation-client-deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: simulation-client
+  name: banking-sim
   namespace: banking-app
   labels:
-    app: simulation-client
+    app: banking-sim
     component: simulation
 spec:
   replicas: 1
@@ -15,11 +15,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      app: simulation-client
+      app: banking-sim
   template:
     metadata:
       labels:
-        app: simulation-client
+        app: banking-sim
         component: simulation
       annotations:
         # Force restart when config changes
@@ -44,9 +44,9 @@ spec:
         
         envFrom:
         - configMapRef:
-            name: simulation-client-config
+            name: banking-sim-config
         - secretRef:
-            name: simulation-client-secret
+            name: banking-sim-secret
         
         resources:
           requests:

--- a/kubernetes/base/deployments/simulation-client-hpa.yaml
+++ b/kubernetes/base/deployments/simulation-client-hpa.yaml
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: simulation-client
+    name: banking-sim
   
   minReplicas: 1
   maxReplicas: 5

--- a/kubernetes/base/deployments/transactions-service-deployment.yaml
+++ b/kubernetes/base/deployments/transactions-service-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: transactions-service
+  name: banking-transactions
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -11,13 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: transactions-service
+      app: banking-transactions
       app.kubernetes.io/name: banking-app
       app.kubernetes.io/component: microservice
   template:
     metadata:
       labels:
-        app: transactions-service
+        app: banking-transactions
         app.kubernetes.io/name: banking-app
         app.kubernetes.io/component: microservice
         app.kubernetes.io/service: transactions-service
@@ -36,12 +36,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: db-credentials
+              name: banking-db-credentials
               key: transactions-service-password
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
-              name: jwt-secret
+              name: banking-jwt-secret
               key: secret
         - name: JAVA_OPTS
           value: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=32m -XX:MaxDirectMemorySize=16m -XX:+UseSerialGC -XX:+UseStringDeduplication -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dspring.main.lazy-initialization=true"
@@ -49,7 +49,7 @@ spec:
         - configMapRef:
             name: app-config
         - configMapRef:
-            name: transactions-service-config
+            name: banking-transactions-config
         resources:
           requests:
             memory: "256Mi"
@@ -84,4 +84,4 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine
-        command: ['sh', '-c', 'echo "[transactions-service] Waiting for PostgreSQL..."; until pg_isready -h postgres -p 5432 -q; do sleep 1; done; echo "[transactions-service] PostgreSQL ready!"']
+        command: ['sh', '-c', 'echo "[transactions-service] Waiting for PostgreSQL..."; until pg_isready -h banking-postgres -p 5432 -q; do sleep 1; done; echo "[transactions-service] PostgreSQL ready!"']

--- a/kubernetes/base/deployments/user-service-deployment.yaml
+++ b/kubernetes/base/deployments/user-service-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: user-service
+  name: banking-user
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -11,13 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: user-service
+      app: banking-user
       app.kubernetes.io/name: banking-app
       app.kubernetes.io/component: microservice
   template:
     metadata:
       labels:
-        app: user-service
+        app: banking-user
         app.kubernetes.io/name: banking-app
         app.kubernetes.io/component: microservice
         app.kubernetes.io/service: user-service
@@ -34,12 +34,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: db-credentials
+              name: banking-db-credentials
               key: user-service-password
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
-              name: jwt-secret
+              name: banking-jwt-secret
               key: secret
         - name: JAVA_OPTS
           value: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=32m -XX:MaxDirectMemorySize=16m -XX:+UseSerialGC -XX:+UseStringDeduplication -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dspring.main.lazy-initialization=true"
@@ -47,7 +47,7 @@ spec:
         - configMapRef:
             name: app-config
         - configMapRef:
-            name: user-service-config
+            name: banking-user-config
         resources:
           requests:
             memory: "256Mi"
@@ -82,4 +82,4 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine
-        command: ['sh', '-c', 'echo "[user-service] Waiting for PostgreSQL..."; until pg_isready -h postgres -p 5432 -q; do sleep 1; done; echo "[user-service] PostgreSQL ready!"']
+        command: ['sh', '-c', 'echo "[user-service] Waiting for PostgreSQL..."; until pg_isready -h banking-postgres -p 5432 -q; do sleep 1; done; echo "[user-service] PostgreSQL ready!"']

--- a/kubernetes/base/ingress/frontend-ingress-alternative.yaml
+++ b/kubernetes/base/ingress/frontend-ingress-alternative.yaml
@@ -18,14 +18,14 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: frontend
+            name: banking-frontend
             port:
               number: 80
       - path: /api
         pathType: Prefix
         backend:
           service:
-            name: api-gateway
+            name: banking-gateway
             port:
               number: 8080
   - host: localhost
@@ -35,13 +35,13 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: frontend
+            name: banking-frontend
             port:
               number: 80
       - path: /api
         pathType: Prefix
         backend:
           service:
-            name: api-gateway
+            name: banking-gateway
             port:
               number: 8080 

--- a/kubernetes/base/ingress/frontend-ingress.yaml
+++ b/kubernetes/base/ingress/frontend-ingress.yaml
@@ -27,13 +27,13 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: frontend
+            name: banking-frontend
             port:
               number: 80
       - path: /api
         pathType: Prefix
         backend:
           service:
-            name: api-gateway
+            name: banking-gateway
             port:
               number: 8080 

--- a/kubernetes/base/services/accounts-service-service.yaml
+++ b/kubernetes/base/services/accounts-service-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: accounts-service
+  name: banking-accounts
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -15,6 +15,6 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: accounts-service
+    app: banking-accounts
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: microservice

--- a/kubernetes/base/services/api-gateway-service.yaml
+++ b/kubernetes/base/services/api-gateway-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: api-gateway
+  name: banking-gateway
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -15,6 +15,6 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: api-gateway
+    app: banking-gateway
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: gateway

--- a/kubernetes/base/services/frontend-service-nodeport.yaml
+++ b/kubernetes/base/services/frontend-service-nodeport.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: frontend-nodeport
+  name: banking-frontend-nodeport
   namespace: banking-app
   labels:
-    app: frontend
+    app: banking-frontend
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: frontend
     app.kubernetes.io/service: frontend
@@ -17,4 +17,4 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: frontend 
+    app: banking-frontend

--- a/kubernetes/base/services/frontend-service.yaml
+++ b/kubernetes/base/services/frontend-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: frontend
+  name: banking-frontend
   namespace: banking-app
   labels:
-    app: frontend
+    app: banking-frontend
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: frontend
     app.kubernetes.io/service: frontend
@@ -16,4 +16,4 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: frontend
+    app: banking-frontend

--- a/kubernetes/base/services/transactions-service-service.yaml
+++ b/kubernetes/base/services/transactions-service-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: transactions-service
+  name: banking-transactions
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -15,6 +15,6 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: transactions-service
+    app: banking-transactions
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: microservice

--- a/kubernetes/base/services/user-service-service.yaml
+++ b/kubernetes/base/services/user-service-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: user-service
+  name: banking-user
   namespace: banking-app
   labels:
     app.kubernetes.io/name: banking-app
@@ -15,6 +15,6 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: user-service
+    app: banking-user
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/component: microservice

--- a/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: accounts-service
+  name: banking-accounts
   namespace: banking-app
   annotations:
     sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: accounts-service
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
-    sidecar.speedscale.com/tls-java-tool-options: "true"
+    sidecar.speedscale.com/inject: "false"
+    capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
+++ b/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: api-gateway
+  name: banking-gateway
   namespace: banking-app
   annotations:
     sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
+++ b/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: api-gateway
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
-    sidecar.speedscale.com/tls-java-tool-options: "true"
+    sidecar.speedscale.com/inject: "false"
+    capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/frontend-annotations.yaml
+++ b/kubernetes/overlays/speedscale/frontend-annotations.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: frontend
+  name: banking-frontend
   namespace: banking-app
   annotations:
     sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/frontend-annotations.yaml
+++ b/kubernetes/overlays/speedscale/frontend-annotations.yaml
@@ -4,5 +4,5 @@ metadata:
   name: frontend
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
+    sidecar.speedscale.com/inject: "false"
+    capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/kustomization.yaml
+++ b/kubernetes/overlays/speedscale/kustomization.yaml
@@ -5,6 +5,18 @@ resources:
 - ../../base
 
 patches:
+# Add Istio injection and Speedscale labels to the existing banking-app namespace
+- target:
+    version: v1
+    kind: Namespace
+    name: banking-app
+  patch: |-
+    - op: add
+      path: /metadata/labels/istio-injection
+      value: enabled
+    - op: add
+      path: /metadata/labels/speedscale
+      value: "true"
 - path: user-service-annotations.yaml
 - path: accounts-service-annotations.yaml
 - path: transactions-service-annotations.yaml

--- a/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
+++ b/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: simulation-client
+  name: banking-sim
   namespace: banking-app
   annotations:
     sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
+++ b/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
@@ -4,10 +4,4 @@ metadata:
   name: simulation-client
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "true"
-    speedscale.com/service-name: "simulation-client"
-spec:
-  template:
-    metadata:
-      annotations:
-        speedscale.com/enabled: "false"
+    sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: transactions-service
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
-    sidecar.speedscale.com/tls-java-tool-options: "true"
+    sidecar.speedscale.com/inject: "false"
+    capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: transactions-service
+  name: banking-transactions
   namespace: banking-app
   annotations:
     sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/user-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/user-service-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: user-service
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
-    sidecar.speedscale.com/tls-java-tool-options: "true"
+    sidecar.speedscale.com/inject: "false"
+    capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/user-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/user-service-annotations.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: user-service
+  name: banking-user
   namespace: banking-app
   annotations:
     sidecar.speedscale.com/inject: "false"


### PR DESCRIPTION
# Problem
Workload names like `api-gateway`, `frontend`, and `user-service` collide with identically-named services in the shared staging-decoy cluster. The existing Speedscale overlay used sidecar injection which conflicts with Istio.

# Solution
- Prefixes all Deployments, Services, ConfigMaps, Secrets, and PVCs with `banking-` (e.g. `api-gateway` → `banking-gateway`, `frontend` → `banking-frontend`)
- Updates all cross-references: service URLs in `app-config`, init container wait targets, ingress backends, HPA `scaleTargetRef`, overlay patches
- Switches Speedscale capture from sidecar injection (`sidecar.speedscale.com/inject: true`) to eBPF (`capture.speedscale.com/enabled: true`) — compatible with Istio sidecar
- Adds `istio-injection: enabled` label to `banking-app` namespace via kustomize patch

## Checklist
- [x] `kubectl kustomize kubernetes/overlays/speedscale` builds clean
- [x] All 7 workloads renamed consistently across 29 files
- [x] Simulation client correctly excluded from capture