### PR TITLE
Fix banking-kafka ImagePullBackOff (bitnami repo purge)

### DIFF
--- a/kubernetes/base/kafka/kafka-deployment.yaml
+++ b/kubernetes/base/kafka/kafka-deployment.yaml
@@ -25,7 +25,9 @@ spec:
       serviceAccountName: banking-app-sa
       containers:
       - name: kafka
-        image: bitnami/kafka:3.7
+        # bitnami/kafka:3.7 was purged from Docker Hub (Aug 2025 Bitnami repo
+        # change); free tags moved to bitnamilegacy/. Pin a concrete patch.
+        image: bitnamilegacy/kafka:3.7.1
         imagePullPolicy: Always
         ports:
         - containerPort: 9092


### PR DESCRIPTION
## Problem

`banking-kafka` is stuck in `ImagePullBackOff` on the staging-decoy cluster: `docker.io/bitnami/kafka:3.7: not found`. Bitnami removed most free `bitnami/*` tags from Docker Hub in the Aug 2025 repository change (the `bitnami/kafka` repo now has **0** tags matching `3.7`). With the broker down, the entire `transaction-events` Kafka pipeline is broken and `notification-service` receives no data.

## Solution

Pin the broker to `bitnamilegacy/kafka:3.7.1` — the free tags moved to the `bitnamilegacy/` org, which keeps the identical `KAFKA_CFG_*` configuration contract, so no other deployment changes are needed. Pinned to a concrete patch (`3.7.1`) rather than a floating minor.

## Checklist
- [x] Verified `bitnamilegacy/kafka:3.7.1` exists on Docker Hub
- [x] No env/config changes required (same Bitnami image family)