### PR TITLE
Fix Docker build: bump Go builder to 1.23-alpine

### DIFF
--- a/backend/fraud-service/Dockerfile
+++ b/backend/fraud-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 

--- a/backend/notification-service/Dockerfile
+++ b/backend/notification-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Problem

`build-and-push` failed for the entire service matrix after #77 merged. Root cause in the build step:

```
go: go.mod requires go >= 1.23.0 (running go 1.22.12; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully
```

Adding `prometheus/client_golang` raised the `go` directive in both Go modules to `go 1.23.0`, but `backend/fraud-service/Dockerfile` and `backend/notification-service/Dockerfile` build on `golang:1.22-alpine` with the default `GOTOOLCHAIN=local`, which refuses to auto-upgrade. The `test-go-services` CI job passed because it installs the toolchain from `go.mod` (`go-version-file`); only the Docker build hardcoded 1.22. The fail-fast matrix then canceled every other service.

## Solution

Bump both builder stages to `golang:1.23-alpine` to match the module `go` directive. Verified locally by building both images and smoke-testing that the containers serve their `/metrics` endpoints.

## Checklist
- [x] `docker build` succeeds for both services locally
- [x] Containers start and serve `/metrics`