### PR TITLE
Fix banking-kafka CrashLoopBackOff (KRaft controller quorum)

### DIFF
--- a/kubernetes/base/kafka/kafka-deployment.yaml
+++ b/kubernetes/base/kafka/kafka-deployment.yaml
@@ -43,8 +43,11 @@ spec:
           value: "PLAINTEXT://:9092,CONTROLLER://:9093"
         - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
           value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+        # Single-node KRaft: the controller quorum is this pod itself. Use
+        # localhost so registration doesn't depend on the ClusterIP Service
+        # routing 9093 back to the same pod (the Service only exposes 9092).
         - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
-          value: "0@banking-kafka:9093"
+          value: "0@localhost:9093"
         - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
           value: "CONTROLLER"
         - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE


### PR DESCRIPTION
## Problem

After the image fix (#78), `banking-kafka` pulls but CrashLoopBackOffs (exit 1) during startup:

```
ERROR [BrokerLifecycleManager id=0] Shutting down because we were unable to register with the controller quorum.
ERROR [BrokerServer id=0] Received a fatal error while waiting for the controller to acknowledge that we are caught up
ERROR Exiting Kafka due to fatal exception during startup.
```

The controller quorum voter was `0@banking-kafka:9093`, but the `banking-kafka` Service only exposes `9092` (plaintext) — not `9093` (controller). So the node could not reach its own controller listener to register, timed out, and exited. This is kafka's first successful image pull on the cluster, so the misconfig had never surfaced. (The pod has no Istio sidecar, so the mesh is not involved.)

## Solution

For this single-node KRaft broker, the controller quorum is the pod itself, so point the voter at `localhost:9093`. This removes the dependency on the ClusterIP Service routing 9093 back to the same pod (hairpin NAT) and needs no Service change.

Verified locally with `bitnamilegacy/kafka:3.7.1` + the full env from the deployment: the broker reaches `Kafka Server started` and stays up (the old config died at registration ~110s in).

## Checklist
- [x] Reproduced the crash and verified the fix locally with the same image + env
- [x] No Service or client-facing (9092) changes required