### PR TITLE
Fix Prometheus scrape targets to banking- service names

### DIFF
--- a/kubernetes/observability/prometheus-config.yaml
+++ b/kubernetes/observability/prometheus-config.yaml
@@ -19,34 +19,29 @@ data:
         static_configs:
           - targets: ['localhost:9090']
 
+      # Services were renamed with the banking- prefix and all expose port 80.
       - job_name: 'user-service'
         static_configs:
-          - targets: ['user-service:8080']
+          - targets: ['banking-user:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'accounts-service'
         static_configs:
-          - targets: ['accounts-service:8080']
+          - targets: ['banking-accounts:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'transactions-service'
         static_configs:
-          - targets: ['transactions-service:8080']
+          - targets: ['banking-transactions:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'api-gateway'
         static_configs:
-          - targets: ['api-gateway:80']
+          - targets: ['banking-gateway:80']
         metrics_path: '/actuator/prometheus'
-        scrape_interval: 30s
-
-      - job_name: 'frontend'
-        static_configs:
-          - targets: ['frontend:3000']
-        metrics_path: '/metrics'
         scrape_interval: 30s
 
       - job_name: 'fraud-service'


### PR DESCRIPTION
## Problem

All pre-existing Java/frontend Prometheus targets are DOWN on the cluster:

```
user-service          down   dial tcp: lookup user-service ... no such host
accounts-service      down   ...
transactions-service  down
api-gateway           down
frontend              down
```

The scrape config still used the old names (`user-service:8080`, `api-gateway:80`, `frontend:3000`), but the services were renamed with the `banking-` prefix (#75) and all expose port `80`. As a result the dashboard's HTTP/JVM/DB panels have never had data. (The new `fraud-service`/`notification-service` jobs were already correct and are `up`.)

## Solution

- Point `user-service` → `banking-user:80`, `accounts-service` → `banking-accounts:80`, `transactions-service` → `banking-transactions:80`, `api-gateway` → `banking-gateway:80`, all on `/actuator/prometheus`. Verified in-cluster that these return Prometheus-format data.
- Drop the `frontend` job: `banking-frontend:80` serves no `/metrics` endpoint (Node app), so it was a permanently-down target.

## Checklist
- [x] Verified target endpoints return data from inside the cluster
- [x] Will apply to cluster and confirm targets go `up` (observability stack is applied manually, not via ArgoCD)