### PR TITLE
Fix frontend HTTP 500 on all /api/* calls (stale api-gateway hostname)

### DIFF
--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -141,9 +141,12 @@ metadata:
     app.kubernetes.io/component: config
     app.kubernetes.io/service: frontend
 data:
-  # Backend API configuration  
-  API_GATEWAY_URL: "http://api-gateway:80"
-  BACKEND_API_URL: "http://api-gateway:80"
+  # Backend API configuration
+  # Service was renamed to banking-gateway in the banking- prefix rename; the
+  # frontend's Next.js proxy routes resolve this host server-side, so a stale
+  # name here makes every /api/* call fail with ENOTFOUND -> HTTP 500.
+  API_GATEWAY_URL: "http://banking-gateway:80"
+  BACKEND_API_URL: "http://banking-gateway:80"
   
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "frontend"


### PR DESCRIPTION
## Problem
Every request through the frontend (`/api/users/login`, `/register`, transactions, etc.) returns **HTTP 500**. The simulation client sends all traffic to `TARGET_BASE_URL=http://banking-frontend:80`, so the entire demo produces zero successful sessions — and because no traffic reaches the new gRPC fraud-service or Kafka notification-service, their dashboards stay empty.

Root cause: the frontend's Next.js proxy routes resolve `API_GATEWAY_URL`/`BACKEND_API_URL` **server-side**, but `banking-frontend-config` still pointed them at the pre-rename host `api-gateway`. After the `banking-` prefix rename that Service is `banking-gateway`, so every proxied call failed with `getaddrinfo ENOTFOUND api-gateway` → `fetch failed` → 500. Kustomize name-prefixing rewrites Service refs in known fields but not arbitrary string values inside ConfigMap data, so these two literals were missed (same bug class as the Prometheus scrape names in #81).

## Solution
Repoint both values at the live Service name `banking-gateway:80`.

Verified live on the decoy cluster: `POST banking-gateway:80/api/users/login` → `200` + JWT, while the identical call via `banking-frontend:80` → `500 ENOTFOUND`. After merge + ArgoCD sync the frontend pod must be restarted to pick up the ConfigMap (envFrom is injected at pod start, not hot-reloaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)