### PR TITLE
Right-size backend CPU limits for live traffic (150m → 1000m)

### DIFF
--- a/kubernetes/base/deployments/accounts-service-deployment.yaml
+++ b/kubernetes/base/deployments/accounts-service-deployment.yaml
@@ -56,7 +56,8 @@ spec:
             cpu: "50m"
           limits:
             memory: "768Mi"
-            cpu: "150m"
+            # Right-sized for live sim traffic; 150m throttled the JVM (see user-service).
+            cpu: "1000m"
         startupProbe:
           tcpSocket:
             port: 8080

--- a/kubernetes/base/deployments/api-gateway-deployment.yaml
+++ b/kubernetes/base/deployments/api-gateway-deployment.yaml
@@ -51,7 +51,8 @@ spec:
             cpu: "50m"
           limits:
             memory: "768Mi"
-            cpu: "150m"
+            # Right-sized for live sim traffic; 150m throttled the JVM (see user-service).
+            cpu: "1000m"
         startupProbe:
           tcpSocket:
             port: 8080

--- a/kubernetes/base/deployments/transactions-service-deployment.yaml
+++ b/kubernetes/base/deployments/transactions-service-deployment.yaml
@@ -56,7 +56,8 @@ spec:
             cpu: "50m"
           limits:
             memory: "768Mi"
-            cpu: "150m"
+            # Right-sized for live sim traffic; 150m throttled the JVM (see user-service).
+            cpu: "1000m"
         startupProbe:
           tcpSocket:
             port: 8080

--- a/kubernetes/base/deployments/user-service-deployment.yaml
+++ b/kubernetes/base/deployments/user-service-deployment.yaml
@@ -54,7 +54,9 @@ spec:
             cpu: "50m"
           limits:
             memory: "768Mi"
-            cpu: "150m"
+            # 150m throttled the JVM so hard under live login load (bcrypt) that
+            # /actuator/health timed out, dropping the pod from ready endpoints.
+            cpu: "1000m"
         startupProbe:
           tcpSocket:
             port: 8080


### PR DESCRIPTION
## Problem
After #82 fixed the frontend's stale gateway hostname, real traffic finally reached the backend — and immediately exposed that all four backend Java services cap CPU at **150m**. Under the simulation client's login load (bcrypt is CPU-heavy), `user-service` pegs its 150m limit, gets hard-throttled, and can no longer answer `/actuator/health` within the 5s readiness timeout. The pod drops out of the ready endpoint set, so Istio returns **`no healthy upstream` (503)** and the gateway's 60s route timeout fires (**504**) — every login through the frontend fails.

Diagnosed live on the decoy cluster: `banking-user` was `1/2 Running` (container `ready=false`, **0 restarts** — throttled, not crashed), CPU pegged at 151m/150m, readiness probe `context deadline exceeded`.

## Solution
Raise the CPU **limit** from `150m` to `1000m` on user-service, accounts-service, transactions-service, and api-gateway. Requests stay at `50m` (no scheduling/QoS change); nodes have ~2.5 cores free, so the higher ceiling simply lets the JVMs burst under load instead of throttling. Memory limits and probes unchanged.

After merge + ArgoCD sync, the rolling update replaces the pods with the new limits — no manual restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)