### PR TITLE
Fix Kafka advertised listeners (clients can't reconnect to pod hostname)

### DIFF
--- a/kubernetes/base/kafka/kafka-deployment.yaml
+++ b/kubernetes/base/kafka/kafka-deployment.yaml
@@ -41,6 +41,11 @@ spec:
           value: "controller,broker"
         - name: KAFKA_CFG_LISTENERS
           value: "PLAINTEXT://:9092,CONTROLLER://:9093"
+        # Without this, KRaft advertises the pod hostname (banking-kafka-<hash>),
+        # which clients can't resolve after bootstrapping via the Service. Pin the
+        # advertised PLAINTEXT listener to the stable Service name.
+        - name: KAFKA_CFG_ADVERTISED_LISTENERS
+          value: "PLAINTEXT://banking-kafka:9092"
         - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
           value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
         # Single-node KRaft: the controller quorum is this pod itself. Use


### PR DESCRIPTION
## Problem
`notification-service` logs a continuous stream of:
`kafka read error: ... failed to open connection to banking-kafka-c8df748d6-...:9092: dial tcp: lookup ... no such host`

`banking-kafka` set `KAFKA_CFG_LISTENERS` but **no advertised listeners**, so KRaft falls back to advertising the **pod hostname**. Clients (the transactions-service producer and notification-service consumer) bootstrap fine via the `banking-kafka` Service, then get redirected to the pod name — which doesn't resolve — and fail on every produce/consume. So no `transaction-events` flow, and the notification dashboard can never populate.

## Solution
Pin `KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://banking-kafka:9092` (the stable Service name). Unblocks both produce and consume. Controller listener is intentionally not advertised (single-node quorum is `0@localhost:9093`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)