### PR TITLE
fix: increase transactions-service MaxMetaspaceSize to 160m

### DIFF
--- a/kubernetes/base/deployments/transactions-service-deployment.yaml
+++ b/kubernetes/base/deployments/transactions-service-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               name: banking-jwt-secret
               key: secret
         - name: JAVA_OPTS
-          value: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=32m -XX:MaxDirectMemorySize=16m -XX:+UseSerialGC -XX:+UseStringDeduplication -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dspring.main.lazy-initialization=true"
+          value: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=160m -XX:ReservedCodeCacheSize=32m -XX:MaxDirectMemorySize=16m -XX:+UseSerialGC -XX:+UseStringDeduplication -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dspring.main.lazy-initialization=true"
         envFrom:
         - configMapRef:
             name: app-config


### PR DESCRIPTION
## Problem
transactions-service crashes with `OutOfMemoryError: Metaspace` under sim traffic. It loads Spring Boot + gRPC client (fraud) + Kafka producer (notifications) — significantly more classes than other services — and 96m Metaspace is insufficient.

## Solution
Increase `MaxMetaspaceSize` from 96m to 160m. Total JVM footprint (192+160+32+16 = 400m) still fits well within the 768Mi container limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)