### PR TITLE
fix: remove banking-app grafana ingress

### DIFF
--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -48,7 +48,6 @@ resources:
 
   # Ingress
   - ingress/frontend-ingress.yaml
-  - ingress/grafana-ingress.yaml
 
 namespace: banking-app
 


### PR DESCRIPTION
Orphaned ingress — grafana deployment already removed in PR #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)