### PR TITLE
Fix OTel Collector bind address for 0.153.0

### DIFF
--- a/kubernetes/observability/otel-collector.yaml
+++ b/kubernetes/observability/otel-collector.yaml
@@ -12,7 +12,9 @@ data:
       otlp:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:4317
           http:
+            endpoint: 0.0.0.0:4318
 
     processors:
       filter:


### PR DESCRIPTION
## Summary
- OTel Collector 0.153.0 defaults receivers to `127.0.0.1` instead of `0.0.0.0`
- Java services send traces to `otel-collector:4317` (pod IP) which can't reach localhost-bound receiver
- Explicitly bind gRPC and HTTP receivers to `0.0.0.0`

Follow-up to #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)