### PR TITLE
Set dummy AI API key for Speedscale responder

### DIFF
--- a/kubernetes/base/configmaps/ai-secret.yaml
+++ b/kubernetes/base/configmaps/ai-secret.yaml
@@ -8,4 +8,4 @@ metadata:
     app.kubernetes.io/component: secrets
 type: Opaque
 stringData:
-  AI_API_KEY: "placeholder-replace-in-cluster"
+  AI_API_KEY: "sk-ant-mock-key-served-by-speedscale-responder"


### PR DESCRIPTION
## Summary
- Change `AI_API_KEY` from empty placeholder to a dummy value so the frontend attempts the outbound call to `api.anthropic.com`
- The Speedscale responder (TrafficReplay CR `replay-banking-frontend`, snapshot `cb1ba7ff`) intercepts the call and returns the recorded mock response
- No real API key is used — the responder serves the response, not Anthropic

## Test plan
- [ ] Frontend AI chat endpoint returns 200 with mock Anthropic response
- [ ] Anthropic traffic appears in eBPF capture (outbound HTTPS to api.anthropic.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)