### PR TITLE
Add frontend proxy route for statement export

### DIFF
--- a/frontend/src/app/api/accounts/[id]/export-statement/route.ts
+++ b/frontend/src/app/api/accounts/[id]/export-statement/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const API_GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:8080';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const resolvedParams = await params;
+
+    const response = await fetch(
+      `${API_GATEWAY_URL}/api/accounts/${resolvedParams.id}/export-statement`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(authHeader && { Authorization: authHeader }),
+        },
+      }
+    );
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('Export statement proxy error:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
# Problem

Sim-client calls POST /api/accounts/:id/export-statement through the frontend BFF, but Next.js file-based router had no route for it — returned 404.

# Solution

Added `frontend/src/app/api/accounts/[id]/export-statement/route.ts` to proxy the POST to the gateway.

## Checklist
- [x] Frontend tests pass (165/165)

🤖 Generated with [Claude Code](https://claude.com/claude-code)