### PR TITLE
Rename demo hostnames to apex-* namespace

### DIFF
--- a/kubernetes/base/ingress/frontend-ingress.yaml
+++ b/kubernetes/base/ingress/frontend-ingress.yaml
@@ -21,7 +21,7 @@ spec:
             name: banking-frontend
             port:
               number: 80
-  - host: banking-staging.trafficreplay.com
+  - host: apex-banking.trafficreplay.com
     http:
       paths:
       - path: /

--- a/kubernetes/base/ingress/grafana-ingress.yaml
+++ b/kubernetes/base/ingress/grafana-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: banking-dev-grafana.trafficreplay.com
+  - host: apex-dev-grafana.trafficreplay.com
     http:
       paths:
       - path: /
@@ -21,7 +21,7 @@ spec:
             name: grafana
             port:
               number: 3000
-  - host: banking-staging-grafana.trafficreplay.com
+  - host: apex-grafana.trafficreplay.com
     http:
       paths:
       - path: /

--- a/kubernetes/observability/grafana.yaml
+++ b/kubernetes/observability/grafana.yaml
@@ -93,7 +93,7 @@ spec:
             - name: GF_USERS_VIEWERS_CAN_EDIT
               value: "true"
             - name: GF_SERVER_ROOT_URL
-              value: https://grafana-staging.trafficreplay.com
+              value: https://apex-grafana.trafficreplay.com
           volumeMounts:
             - name: data
               mountPath: /var/lib/grafana
@@ -156,7 +156,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: grafana-staging.trafficreplay.com
+    - host: apex-grafana.trafficreplay.com
       http:
         paths:
           - path: /

--- a/kubernetes/observability/jaeger-ingress.yaml
+++ b/kubernetes/observability/jaeger-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: jaeger-staging.trafficreplay.com
+  - host: apex-jaeger.trafficreplay.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Problem

Demo hostnames (`grafana-staging`, `jaeger-staging`, `banking-staging`) are too similar to production (`grafana-staging.speedscale.com`). The grafana/jaeger rename was dropped from the PR #105 squash merge. Banking app frontend also needs renaming for consistency.

## Solution

Rename all demo endpoints:
- `banking-staging.trafficreplay.com` → `apex-banking.trafficreplay.com`
- `grafana-staging.trafficreplay.com` → `apex-grafana.trafficreplay.com`
- `jaeger-staging.trafficreplay.com` → `apex-jaeger.trafficreplay.com`

After merge, add Cloudflare DNS CNAME records for all three pointing to the nginx ingress LB (`143.244.200.56`).

## Checklist
- [x] Observability ingresses updated (grafana, jaeger)
- [x] Frontend ingress updated (banking app)
- [x] Grafana GF_SERVER_ROOT_URL updated
- [x] Base grafana-ingress.yaml updated for consistency (not currently in kustomization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)