### PR TITLE
Fix input placeholder contrast on login page

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -16,7 +16,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({
   id,
   ...props
 }, ref) => {
-  const baseStyles = 'block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors';
+  const baseStyles = 'block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors';
   const errorStyles = error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : '';
   const combinedClassName = `${baseStyles} ${errorStyles} ${className}`;
   


### PR DESCRIPTION
# Problem
Input placeholder text (`placeholder-gray-400`) on white background fails WCAG AA contrast.

# Solution
Bump to `placeholder-gray-600`.

## Checklist
- [x] Single-line Tailwind class change in `Input.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)