### PR TITLE
Add burst mode for realistic traffic patterns

### DIFF
--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -11,37 +11,49 @@ data:
   NODE_ENV: "production"
   LOG_LEVEL: "info"
   LOG_FORMAT: "json"
-  
+
   # Target application settings
   TARGET_BASE_URL: "http://banking-frontend:80"
   NOTIFICATION_SERVICE_URL: "http://banking-notification:80"
-  REQUEST_TIMEOUT: "10000"
-  
-  # Simulation settings
+  REQUEST_TIMEOUT: "15000"
+
+  # Simulation settings — burst mode produces spiky, realistic traffic
   CONCURRENT_USERS: "5"
   EXISTING_USER_PERCENTAGE: "80"
-  SESSION_DURATION_MS: "300000"  # 5 minutes
-  MIN_ACTION_DELAY: "1000"       # 1 second
-  MAX_ACTION_DELAY: "5000"       # 5 seconds
-  NEW_USER_DELAY: "2000"         # 2 seconds
+  SESSION_DURATION_MS: "300000"
+  MIN_ACTION_DELAY: "1500"
+  MAX_ACTION_DELAY: "6000"
+  NEW_USER_DELAY: "3000"
   MAX_RETRIES: "3"
   RETRY_DELAY: "1000"
-  
+
+  # Burst mode: quiet baseline with periodic traffic spikes
+  BURST_ENABLED: "true"
+  BURST_BASE_USERS: "2"           # quiet: 2 concurrent users
+  BURST_PEAK_USERS: "12"          # spike: 12 concurrent users
+  BURST_INTERVAL_MS: "180000"     # ~3 min between bursts
+  BURST_DURATION_MS: "30000"      # each burst lasts ~30s
+  BURST_JITTER_MS: "60000"        # ±60s randomness on interval
+
   # User pool configuration
   USER_PREFIX: "sim_user_"
   TOTAL_USERS: "1000"
-  
+
   # Transaction simulation settings
-  DEPOSIT_PROBABILITY: "0.3"
-  WITHDRAWAL_PROBABILITY: "0.2"
-  TRANSFER_PROBABILITY: "0.1"
+  DEPOSIT_PROBABILITY: "0.4"
+  WITHDRAWAL_PROBABILITY: "0.15"
+  TRANSFER_PROBABILITY: "0.05"
   MIN_DEPOSIT: "10.00"
   MAX_DEPOSIT: "1000.00"
   MIN_WITHDRAWAL: "5.00"
   MAX_WITHDRAWAL: "500.00"
   MIN_TRANSFER: "10.00"
   MAX_TRANSFER: "250.00"
-  
+
+  # Feature toggles — disable endpoints that lack backend support
+  AI_CHAT_ENABLED: "false"
+  EXPORT_STATEMENT_ENABLED: "false"
+
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "simulation-client"
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
@@ -52,6 +64,6 @@ data:
   OTEL_TRACES_SAMPLER: "always_on"
   OTEL_PROPAGATORS: "tracecontext"
   OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app"
-  
+
   # Metrics reporting
-  METRICS_INTERVAL: "30000"      # 30 seconds
+  METRICS_INTERVAL: "30000"

--- a/simulation-client/src/config/index.js
+++ b/simulation-client/src/config/index.js
@@ -17,24 +17,34 @@ const config = {
 
   // Simulation settings
   simulation: {
-    // Number of concurrent users to simulate
+    // Number of concurrent users (fallback when burst mode is off)
     concurrentUsers: parseInt(process.env.CONCURRENT_USERS) || 10,
-    
+
     // Percentage of users that are pre-existing (vs new registrations)
     existingUserPercentage: parseInt(process.env.EXISTING_USER_PERCENTAGE) || 80,
-    
+
     // Session duration in milliseconds
-    sessionDurationMs: parseInt(process.env.SESSION_DURATION_MS) || 300000, // 5 minutes
-    
+    sessionDurationMs: parseInt(process.env.SESSION_DURATION_MS) || 300000,
+
     // Delay between user actions (milliseconds)
     actionDelayMs: {
-      min: parseInt(process.env.MIN_ACTION_DELAY) || 1000,   // 1 second
-      max: parseInt(process.env.MAX_ACTION_DELAY) || 5000    // 5 seconds
+      min: parseInt(process.env.MIN_ACTION_DELAY) || 1000,
+      max: parseInt(process.env.MAX_ACTION_DELAY) || 5000
     },
-    
+
     // Delay between starting new user sessions
-    newUserDelayMs: parseInt(process.env.NEW_USER_DELAY) || 2000, // 2 seconds
-    
+    newUserDelayMs: parseInt(process.env.NEW_USER_DELAY) || 2000,
+
+    // Burst mode: alternate between quiet baseline and traffic spikes
+    burst: {
+      enabled: (process.env.BURST_ENABLED || 'true') === 'true',
+      baseConcurrentUsers: parseInt(process.env.BURST_BASE_USERS) || 2,
+      burstConcurrentUsers: parseInt(process.env.BURST_PEAK_USERS) || 12,
+      intervalMs: parseInt(process.env.BURST_INTERVAL_MS) || 180000,       // 3 min between bursts
+      durationMs: parseInt(process.env.BURST_DURATION_MS) || 30000,        // 30s burst
+      intervalJitterMs: parseInt(process.env.BURST_JITTER_MS) || 60000     // ±60s jitter
+    },
+
     // Retry settings
     maxRetries: parseInt(process.env.MAX_RETRIES) || 3,
     retryDelayMs: parseInt(process.env.RETRY_DELAY) || 1000
@@ -50,6 +60,12 @@ const config = {
     
     // Common password for simulation users
     password: process.env.SIM_USER_PASSWORD || 'SimUser123!'
+  },
+
+  // Feature toggles
+  features: {
+    aiChatEnabled: (process.env.AI_CHAT_ENABLED || 'true') === 'true',
+    exportStatementEnabled: (process.env.EXPORT_STATEMENT_ENABLED || 'true') === 'true'
   },
 
   // Transaction simulation settings

--- a/simulation-client/src/workflows/SimulationManager.js
+++ b/simulation-client/src/workflows/SimulationManager.js
@@ -9,6 +9,7 @@ class SimulationManager {
     this.userWorkflow = new UserWorkflow(apiClient);
     this.isRunning = false;
     this.activeSessions = new Map();
+    this.burstActive = false;
     this.metrics = {
       totalSessions: 0,
       successfulSessions: 0,
@@ -28,22 +29,25 @@ class SimulationManager {
 
     this.isRunning = true;
     this.metrics.startTime = new Date();
-    
+
     logger.info('Starting user simulation', {
-      concurrentUsers: config.simulation.concurrentUsers,
-      existingUserPercentage: config.simulation.existingUserPercentage,
+      burstMode: config.simulation.burst.enabled,
+      baseConcurrency: config.simulation.burst.baseConcurrentUsers,
+      burstConcurrency: config.simulation.burst.burstConcurrentUsers,
+      burstInterval: `${config.simulation.burst.intervalMs / 1000}s`,
+      burstDuration: `${config.simulation.burst.durationMs / 1000}s`,
       targetUrl: config.target.baseUrl
     });
 
-    // Start health check monitoring
     this.startHealthChecks();
-    
-    // Start metrics reporting
     this.startMetricsReporting();
-    
-    // Start user session generation
+
+    if (config.simulation.burst.enabled) {
+      this.startBurstCycle();
+    }
+
     this.startUserSessionGeneration();
-    
+
     logger.info('User simulation started successfully');
   }
 
@@ -54,23 +58,86 @@ class SimulationManager {
     }
 
     this.isRunning = false;
-    
+
     logger.info('Stopping user simulation...');
-    
-    // Wait for active sessions to complete (with timeout)
-    await this.waitForActiveSessions(30000); // 30 second timeout
-    
+    await this.waitForActiveSessions(30000);
+
     logger.info('User simulation stopped', {
       finalMetrics: this.getMetrics()
     });
   }
 
+  // Burst cycle: alternate between quiet periods and traffic spikes.
+  // Adds jitter so bursts don't land on exact clock boundaries.
+  startBurstCycle() {
+    const scheduleBurst = () => {
+      if (!this.isRunning) return;
+
+      const jitter = (Math.random() - 0.5) * config.simulation.burst.intervalJitterMs * 2;
+      const nextBurstIn = config.simulation.burst.intervalMs + jitter;
+
+      setTimeout(async () => {
+        if (!this.isRunning) return;
+
+        const durationJitter = (Math.random() - 0.5) * config.simulation.burst.durationMs * 0.4;
+        const burstDuration = config.simulation.burst.durationMs + durationJitter;
+
+        this.burstActive = true;
+        logger.info('Burst started', {
+          concurrency: config.simulation.burst.burstConcurrentUsers,
+          plannedDuration: `${Math.round(burstDuration / 1000)}s`
+        });
+
+        setTimeout(() => {
+          this.burstActive = false;
+          logger.info('Burst ended, returning to base traffic');
+          scheduleBurst();
+        }, burstDuration);
+
+      }, nextBurstIn);
+    };
+
+    // First burst after a shorter initial wait (30-90s) so the demo isn't boring
+    const initialDelay = 30000 + Math.random() * 60000;
+    setTimeout(() => {
+      if (!this.isRunning) return;
+      this.burstActive = true;
+      logger.info('Initial burst started');
+
+      const dur = config.simulation.burst.durationMs * (0.5 + Math.random() * 0.5);
+      setTimeout(() => {
+        this.burstActive = false;
+        logger.info('Initial burst ended');
+        scheduleBurst();
+      }, dur);
+    }, initialDelay);
+  }
+
+  getCurrentConcurrency() {
+    if (!config.simulation.burst.enabled) {
+      return config.simulation.concurrentUsers;
+    }
+    return this.burstActive
+      ? config.simulation.burst.burstConcurrentUsers
+      : config.simulation.burst.baseConcurrentUsers;
+  }
+
+  getCurrentDelay() {
+    if (!config.simulation.burst.enabled) {
+      return config.simulation.newUserDelayMs;
+    }
+    // During bursts: faster session starts. During quiet: slower.
+    return this.burstActive
+      ? Math.max(200, config.simulation.newUserDelayMs / 4)
+      : config.simulation.newUserDelayMs * 2;
+  }
+
   async startHealthChecks() {
-    const healthCheckInterval = 30000; // 30 seconds
-    
+    const healthCheckInterval = 30000;
+
     const checkHealth = async () => {
       if (!this.isRunning) return;
-      
+
       try {
         await this.apiClient.healthCheck();
         logger.debug('Health check passed');
@@ -80,59 +147,57 @@ class SimulationManager {
           status: error.response?.status
         });
       }
-      
+
       if (this.isRunning) {
         setTimeout(checkHealth, healthCheckInterval);
       }
     };
-    
-    // Initial health check
-    setTimeout(checkHealth, 5000); // Wait 5 seconds before first check
+
+    setTimeout(checkHealth, 5000);
   }
 
   startMetricsReporting() {
     const reportMetrics = () => {
       if (!this.isRunning) return;
-      
+
       const metrics = this.getMetrics();
       logger.info('Simulation metrics', metrics);
-      
+
       if (this.isRunning) {
         setTimeout(reportMetrics, config.observability.metricsIntervalMs);
       }
     };
-    
+
     setTimeout(reportMetrics, config.observability.metricsIntervalMs);
   }
 
   async startUserSessionGeneration() {
     while (this.isRunning) {
       try {
-        // Check if we're at capacity
-        if (this.activeSessions.size >= config.simulation.concurrentUsers) {
-          await this.delay(1000); // Wait 1 second before checking again
+        const maxConcurrency = this.getCurrentConcurrency();
+
+        if (this.activeSessions.size >= maxConcurrency) {
+          await this.delay(1000);
           continue;
         }
 
-        // Generate new user session
         const user = this.generateUser();
         this.startUserSession(user);
-        
-        // Wait before starting next user
-        await this.delay(config.simulation.newUserDelayMs);
-        
+
+        await this.delay(this.getCurrentDelay());
+
       } catch (error) {
         logger.error('Error in user session generation', {
           error: error.message
         });
-        await this.delay(5000); // Wait 5 seconds before retrying
+        await this.delay(5000);
       }
     }
   }
 
   generateUser() {
     const useExistingUser = Math.random() < (config.simulation.existingUserPercentage / 100);
-    
+
     if (useExistingUser) {
       const userNumber = Math.floor(Math.random() * config.userPool.totalUsers) + 1;
       return User.generateSimulationUser(userNumber);
@@ -145,7 +210,7 @@ class SimulationManager {
     const sessionId = this.generateSessionId();
     this.activeSessions.set(sessionId, user);
     this.metrics.totalSessions++;
-    
+
     if (user.isPreExisting) {
       this.metrics.existingUserLogins++;
     } else {
@@ -155,10 +220,10 @@ class SimulationManager {
     logger.debug('Starting user session', {
       sessionId,
       user: user.toLogData(),
-      activeSessions: this.activeSessions.size
+      activeSessions: this.activeSessions.size,
+      burstActive: this.burstActive
     });
 
-    // Execute user workflow asynchronously
     this.executeUserSessionAsync(sessionId, user);
   }
 
@@ -166,24 +231,24 @@ class SimulationManager {
     try {
       await this.userWorkflow.executeUserSession(user);
       this.metrics.successfulSessions++;
-      
+
       logger.debug('User session completed successfully', {
         sessionId,
         user: user.toLogData()
       });
-      
+
     } catch (error) {
       this.metrics.failedSessions++;
-      
+
       logger.error('User session failed', {
         sessionId,
         user: user.toLogData(),
         error: error.message
       });
-      
+
     } finally {
       this.activeSessions.delete(sessionId);
-      
+
       logger.debug('User session ended', {
         sessionId,
         activeSessions: this.activeSessions.size
@@ -193,12 +258,12 @@ class SimulationManager {
 
   async waitForActiveSessions(timeoutMs) {
     const startTime = Date.now();
-    
+
     while (this.activeSessions.size > 0 && (Date.now() - startTime) < timeoutMs) {
       logger.info(`Waiting for ${this.activeSessions.size} active sessions to complete...`);
       await this.delay(1000);
     }
-    
+
     if (this.activeSessions.size > 0) {
       logger.warn(`Timed out waiting for sessions. ${this.activeSessions.size} sessions still active.`);
     } else {
@@ -213,21 +278,23 @@ class SimulationManager {
   getMetrics() {
     const runtime = this.metrics.startTime ? Date.now() - this.metrics.startTime.getTime() : 0;
     const runtimeMinutes = Math.floor(runtime / 60000);
-    
+
     return {
       runtime: `${runtimeMinutes} minutes`,
       runtimeMs: runtime,
       activeSessions: this.activeSessions.size,
+      burstActive: this.burstActive,
+      currentConcurrency: this.getCurrentConcurrency(),
       totalSessions: this.metrics.totalSessions,
       successfulSessions: this.metrics.successfulSessions,
       failedSessions: this.metrics.failedSessions,
-      successRate: this.metrics.totalSessions > 0 
+      successRate: this.metrics.totalSessions > 0
         ? Math.round((this.metrics.successfulSessions / this.metrics.totalSessions) * 100) + '%'
         : '0%',
       newUserRegistrations: this.metrics.newUserRegistrations,
       existingUserLogins: this.metrics.existingUserLogins,
       totalTransactions: this.metrics.totalTransactions,
-      sessionsPerMinute: runtimeMinutes > 0 
+      sessionsPerMinute: runtimeMinutes > 0
         ? Math.round(this.metrics.totalSessions / runtimeMinutes)
         : 0
     };

--- a/simulation-client/src/workflows/UserWorkflow.js
+++ b/simulation-client/src/workflows/UserWorkflow.js
@@ -55,7 +55,7 @@ class UserWorkflow {
     await this.randomDelay();
 
     // Step 4b: Occasionally export a statement to S3
-    if (Math.random() < 0.1 && user.accounts && user.accounts.length > 0) {
+    if (config.features.exportStatementEnabled && Math.random() < 0.1 && user.accounts && user.accounts.length > 0) {
       await this.exportStatement(user, user.accounts);
       await this.randomDelay();
     }
@@ -70,7 +70,7 @@ class UserWorkflow {
     await this.randomDelay();
 
     // Step 7: 30% chance of asking the AI assistant a question
-    if (Math.random() < 0.3) {
+    if (config.features.aiChatEnabled && Math.random() < 0.3) {
       await this.askAIAssistant(user);
       await this.randomDelay();
     }


### PR DESCRIPTION
# Problem

Simulation client generates flat, constant traffic at 5 concurrent users. This produces:
- Monotone throughput (flat line on Grafana)
- Steady error rate with no variation
- Unrealistic for a banking app demo

Separately, the error rate is 67% because:
1. **Speedscale responder is crash-looping** (261 restarts) → 2 req/s of 503s (85% of all errors). Scale it to 0:
   ```
   kubectl scale deploy speedscale-responder-banking-frontend-replay-banking-frontend -n banking-app --replicas=0
   kubectl scale deploy speedscale-redis-replay-banking-frontend -n banking-app --replicas=0
   ```
2. AI chat and S3 export endpoints have no backend → always 500

# Solution

**Burst mode** (on by default): alternates between quiet baseline and traffic spikes.
- Base: 2 concurrent users
- Burst: 12 concurrent users for ~30s every ~3min
- ±60s jitter on burst interval so it looks organic
- First burst within 30-90s of startup

**Feature toggles** to skip broken endpoints:
- `AI_CHAT_ENABLED=false` (no API key configured)
- `EXPORT_STATEMENT_ENABLED=false` (S3 not set up)

**Tuned transaction mix**: more deposits (safe), fewer withdrawals/transfers (error-prone on low balance).

## Checklist
- [x] SimulationManager burst cycle with jitter
- [x] Config: burst params, feature toggles
- [x] UserWorkflow respects feature toggles
- [x] ConfigMap updated with production defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)