### PR TITLE
Fix flaky CI: retry proxymock init on network timeout

### DIFF
--- a/scripts/run-proxymock-validation.sh
+++ b/scripts/run-proxymock-validation.sh
@@ -38,7 +38,17 @@ if echo "$PM_VER_OUT" | grep -Fq "not initialized"; then
     echo "Set GitHub secret PROXYMOCK_API_KEY or run: proxymock init --api-key <key>"
     exit 0
   fi
-  proxymock init -y --app-url app.speedscale.com --api-key "$PROXYMOCK_API_KEY"
+  for attempt in 1 2 3; do
+    if proxymock init -y --app-url app.speedscale.com --api-key "$PROXYMOCK_API_KEY"; then
+      break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+      echo "error: proxymock init failed after 3 attempts"
+      exit 1
+    fi
+    echo "proxymock init attempt $attempt failed, retrying in 10s..."
+    sleep 10
+  done
 fi
 
 # Fail fast if host port 5432 is taken (proxymock Postgres mock needs it); nc is optional.

--- a/scripts/test-postgres-mock.sh
+++ b/scripts/test-postgres-mock.sh
@@ -38,7 +38,17 @@ if echo "$PM_VER_OUT" | grep -Fq "not initialized"; then
     echo "Skipping proxymock validation: not initialized and no API key (set PROXYMOCK_API_KEY)."
     exit 0
   fi
-  proxymock init -y --app-url app.speedscale.com --api-key "$PROXYMOCK_API_KEY"
+  for attempt in 1 2 3; do
+    if proxymock init -y --app-url app.speedscale.com --api-key "$PROXYMOCK_API_KEY"; then
+      break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+      echo "error: proxymock init failed after 3 attempts"
+      exit 1
+    fi
+    echo "proxymock init attempt $attempt failed, retrying in 10s..."
+    sleep 10
+  done
 fi
 
 # Clean up any existing processes


### PR DESCRIPTION
## Problem

The `proxymock-validation` CI job intermittently fails with `context deadline exceeded` when the GitHub Actions runner can't reach `app.speedscale.com` during `proxymock init`. This is a transient network issue — not a code bug — but it blocks unrelated PRs (e.g. PR #108).

## Solution

Added a retry loop (3 attempts, 10s backoff) around `proxymock init` in both `scripts/run-proxymock-validation.sh` and `scripts/test-postgres-mock.sh`. If all 3 attempts fail, the job still exits non-zero with a clear error.

Fixes S-11862