### PR TITLE
Fix invisible input text on dark mode systems

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,12 +12,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+/* Dark mode disabled — app is light-theme only */
 
 body {
   background: var(--background);

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -16,7 +16,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({
   id,
   ...props
 }, ref) => {
-  const baseStyles = 'block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors';
+  const baseStyles = 'block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-gray-900 bg-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors';
   const errorStyles = error ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : '';
   const combinedClassName = `${baseStyles} ${errorStyles} ${className}`;
   


### PR DESCRIPTION
## Summary
- Root cause: `globals.css` dark mode media query set `--foreground: #ededed` (near-white), inherited by all inputs against white backgrounds
- Removed unused dark mode block — app is light-theme only, no dark mode support
- Added explicit `text-gray-900 bg-white` on Input component as defense in depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)