### PR TITLE
Fix banking health dashboard scope and generate bursty error traffic

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -5,7 +5,7 @@
   "tags": ["banking-app", "health", "golden-signals"],
   "editable": true,
   "schemaVersion": 39,
-  "version": 10,
+  "version": 11,
   "time": {"from": "now-30m", "to": "now"},
   "refresh": "10s",
   "panels": [
@@ -33,13 +33,13 @@
     },
     {
       "type": "timeseries",
-      "title": "Throughput — Requests / sec (eBPF)",
-      "description": "HTTP throughput derived from Speedscale eBPF capture across all services",
+      "title": "Throughput — Requests / sec",
+      "description": "HTTP request rate per banking service (Spring http_server_requests; actuator/health excluded). Banking-app namespace only.",
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum(rate(speedscale_calls_total[5m]))", "legendFormat": "total req/s", "refId": "A"},
-        {"expr": "sum by (svc) (rate(speedscale_calls_total[5m]))", "legendFormat": "{{svc}}", "refId": "B"}
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[5m]))", "legendFormat": "total req/s", "refId": "A"},
+        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[5m]))", "legendFormat": "{{job}}", "refId": "B"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -101,11 +101,11 @@
     {
       "type": "timeseries",
       "title": "Error Rate — by Service & Status",
-      "description": "HTTP 4xx/5xx errors detected by Speedscale eBPF capture, by service and status code",
+      "description": "Banking-app HTTP 4xx/5xx by service and status code (Spring http_server_requests; actuator/health excluded).",
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum by (svc, status) (rate(speedscale_calls_total{status=~\"[45]..\"}[5m]))", "legendFormat": "{{svc}} {{status}}", "refId": "A"}
+        {"expr": "sum by (job, status) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m]))", "legendFormat": "{{job}} {{status}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -125,11 +125,11 @@
     {
       "type": "stat",
       "title": "Error Rate %",
-      "description": "Percentage of all requests returning 4xx/5xx (from eBPF capture)",
+      "description": "Percentage of banking-app requests returning 4xx/5xx (actuator/health excluded).",
       "gridPos": {"h": 8, "w": 4, "x": 12, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum(rate(speedscale_calls_total{status=~\"[45]..\"}[5m])) / sum(rate(speedscale_calls_total[5m])) * 100", "refId": "A"}
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[5m])) * 100", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -152,11 +152,11 @@
     {
       "type": "timeseries",
       "title": "eBPF Capture — Messages by Protocol",
-      "description": "Speedscale eBPF capture rate by protocol. Shows HTTP, Postgres, MongoDB, Kafka, Redis, gRPC traffic flowing through the pipeline.",
+      "description": "Speedscale eBPF capture rate by protocol for the banking-app namespace. Shows HTTP, Postgres, MongoDB, Kafka, Redis, gRPC traffic flowing through the pipeline.",
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 16},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "sum by (protocol) (rate(messages_sent_total{component=\"forwarder\"}[5m]))", "legendFormat": "{{protocol}}", "refId": "A"}
+        {"expr": "sum by (protocol) (rate(messages_sent_total{component=\"forwarder\", k8sAppPodNamespace=\"banking-app\"}[5m]))", "legendFormat": "{{protocol}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {

--- a/simulation-client/src/config/index.js
+++ b/simulation-client/src/config/index.js
@@ -47,7 +47,17 @@ const config = {
 
     // Retry settings
     maxRetries: parseInt(process.env.MAX_RETRIES) || 3,
-    retryDelayMs: parseInt(process.env.RETRY_DELAY) || 1000
+    retryDelayMs: parseInt(process.env.RETRY_DELAY) || 1000,
+
+    // Error injection: each session has a chance to run one realistic
+    // "unhappy path" (bad login, expired token, missing account, overdraw,
+    // invalid amount). Because burst mode scales the number of concurrent
+    // sessions, the absolute error rate rises and falls *with* throughput —
+    // which is what the Banking Health error panel is meant to show.
+    errorInjection: {
+      enabled: (process.env.ERROR_INJECTION_ENABLED || 'true') === 'true',
+      probability: parseFloat(process.env.ERROR_INJECTION_PROBABILITY) || 0.25
+    }
   },
 
   // Pre-existing user pool

--- a/simulation-client/src/workflows/UserWorkflow.js
+++ b/simulation-client/src/workflows/UserWorkflow.js
@@ -19,7 +19,10 @@ class UserWorkflow {
         await this.executeNewUserWorkflow(user);
       }
 
-      logger.info('Completed user session', { 
+      // Realistic unhappy-path traffic so the error-rate dashboard moves with load.
+      await this.generateErrorTraffic(user);
+
+      logger.info('Completed user session', {
         user: user.toLogData(),
         sessionDuration: user.getSessionDuration()
       });
@@ -499,6 +502,80 @@ class UserWorkflow {
       logger.warn('AI assistant request failed', {
         userId: user.id,
         error: error.message,
+      });
+    }
+  }
+
+  // Generate one realistic "unhappy path" request that the backend rejects with
+  // a 4xx. These are intentional and expected — they exist so the error-rate
+  // panels show non-zero, service-attributed errors that scale with traffic.
+  // Spread across services: user (401), gateway (401), accounts (404),
+  // transactions (400). 4xx responses are not retried by ApiClient.
+  async generateErrorTraffic(user) {
+    if (!config.simulation.errorInjection.enabled) return;
+    if (Math.random() >= config.simulation.errorInjection.probability) return;
+
+    const account = user.accounts && user.accounts.length > 0 ? user.accounts[0] : null;
+
+    // Only pick scenarios we can actually exercise for this user.
+    const scenarios = ['badLogin', 'expiredToken', 'missingAccount'];
+    if (account) {
+      scenarios.push('overdraw', 'invalidAmount');
+    }
+    const scenario = scenarios[Math.floor(Math.random() * scenarios.length)];
+
+    try {
+      switch (scenario) {
+        case 'badLogin':
+          // Wrong password -> 401 at user-service.
+          await this.apiClient.login({
+            usernameOrEmail: user.username,
+            password: 'definitely-not-the-password',
+          });
+          break;
+
+        case 'expiredToken':
+          // Garbage bearer token -> 401 at the API gateway JWT filter.
+          await this.apiClient.getAccounts('invalid.expired.token');
+          break;
+
+        case 'missingAccount':
+          // Non-existent account id -> 404 at accounts-service.
+          await this.apiClient.getAccountBalance(999999999, user.token);
+          break;
+
+        case 'overdraw':
+          // Withdraw far beyond balance -> 4xx at transactions-service.
+          await this.apiClient.createTransaction({
+            type: 'WITHDRAWAL',
+            amount: 100000000,
+            accountId: account.id,
+            description: 'Simulated overdraw (expected failure)',
+          }, user.token);
+          break;
+
+        case 'invalidAmount':
+          // Negative amount -> 400 validation error at transactions-service.
+          await this.apiClient.createTransaction({
+            type: 'DEPOSIT',
+            amount: -100,
+            accountId: account.id,
+            description: 'Simulated invalid amount (expected failure)',
+          }, user.token);
+          break;
+      }
+
+      // Reached only if the backend unexpectedly accepted the bad request.
+      logger.debug('Error scenario did not produce an error', {
+        scenario,
+        userId: user.id,
+      });
+    } catch (error) {
+      // Expected path: this is intentional error traffic for observability.
+      logger.debug('Generated expected error traffic', {
+        scenario,
+        userId: user.id,
+        status: error.response?.status,
       });
     }
   }


### PR DESCRIPTION
## What & why

The **Banking Application — Health** dashboard sourced its Throughput, Error Rate, and Error % panels from the cluster-wide eBPF metric `speedscale_calls_total`, which carries no namespace label. Verified against the live cluster (via Grafana's anonymous datasource API), this caused three problems:

1. **Error rate looked permanently flat.** The constant ~0.18 req/s of 500s came from *other namespaces'* apps (`frontend`, `outerspace-server`) — `banking-frontend` itself had **zero** 500s. A constant foreign-500 baseline ignores the banking app's bursty traffic, so the line never moved.
2. **banking-accounts showed 0 traffic** even though `accounts-service` is fully healthy (~1.3 req/s, all 200/201 at the app level). The Speedscale nettap simply isn't emitting a `banking-accounts` series (same for transactions/fraud) — a **runtime capture gap**, not a repo bug (the per-service capture annotations are identical to the captured `user-service`).
3. **Other namespaces polluted every panel** because the metric is cluster-wide.

## Changes

### Dashboard — `kubernetes/observability/dashboards/banking-app-health.json`
Rebuilt the three eBPF-sourced panels on the app-scoped Spring metric `http_server_requests_seconds_count`, filtered to banking jobs (`api-gateway|accounts-service|transactions-service|user-service`) and excluding `/actuator.*`:
- **Throughput** — by `job`; accounts-service reappears.
- **Error Rate by Service & Status** — by `job,status`; banking-only, the foreign-500 flatline is gone, errors scale with load.
- **Error Rate %** — same app-metric basis.
- **eBPF Protocol panel** — kept (only source with a protocol breakdown) but scoped to `k8sAppPodNamespace="banking-app"` (that metric *does* carry a namespace label).

Latency / CPU / Memory were already job-scoped and untouched. Dashboard version bumped 10→11.

### Simulation — `simulation-client/`
Added **load-proportional error injection** so the error panels have realistic, service-attributed traffic that bursts with throughput:
- `config/index.js`: new `errorInjection` block (enabled, 25% per session, env-overridable via `ERROR_INJECTION_ENABLED` / `ERROR_INJECTION_PROBABILITY`).
- `UserWorkflow.js`: each session may run one realistic unhappy path — **badLogin → 401** (user), **expiredToken → 401** (gateway), **missingAccount → 404** (accounts), **overdraw / invalidAmount → 400** (transactions). 4xx are not retried by `ApiClient`.

Because burst mode runs ~6× more concurrent sessions during a spike (12 vs 2), per-session error injection makes errors **batch with throughput** instead of sitting flat at zero.

## How it maps to the reported issues
| Observation | Root cause | Fix |
|---|---|---|
| Error rate flat | Constant 500s from other namespaces | App-metric error panel (banking-only) + sim generates load-proportional 4xx |
| accounts traffic 0 | eBPF nettap not emitting `banking-accounts` (runtime gap) | Dashboard reads app metrics → accounts visible |
| Demo not filling out error traffic | No deliberate error traffic existed | Error injection across all 4 services |
| Other namespaces included | Cluster-wide eBPF metric, no ns label | App metrics (job-scoped) + protocol panel ns-filtered |

## Testing
- Every PromQL query validated live against the cluster: accounts shows ~0.92 req/s, errors are banking-only, error% ~1.2%.
- Dashboard JSON validated; zero `speedscale_calls_total` references remain.
- Simulation JS syntax-checked (`node -c`). Jest not run locally (no `node_modules`).

## Notes for reviewers
- No version files touched — these aren't `backend/<service>` code changes, and CI auto-versions on merge to master.
- The nettap eBPF capture gap for accounts/transactions/fraud is a separate, cluster-side investigation (out of scope here).
- Dashboard ships via ConfigMap/provisioning (next observability apply); the sim change ships in the next `simulation-client` image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)