### PR TITLE
Use 1m rate window so error panels spike and return to zero

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -5,7 +5,7 @@
   "tags": ["banking-app", "health", "golden-signals"],
   "editable": true,
   "schemaVersion": 39,
-  "version": 11,
+  "version": 12,
   "time": {"from": "now-30m", "to": "now"},
   "refresh": "10s",
   "panels": [
@@ -38,8 +38,8 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[5m]))", "legendFormat": "total req/s", "refId": "A"},
-        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[5m]))", "legendFormat": "{{job}}", "refId": "B"}
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "total req/s", "refId": "A"},
+        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}}", "refId": "B"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -105,7 +105,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum by (job, status) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m]))", "legendFormat": "{{job}} {{status}}", "refId": "A"}
+        {"expr": "sum by (job, status) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}} {{status}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
## What & why

Follow-up to #114. On the live dashboard the error line still looked like a constant band of "a lot of errors" that never returned to zero — even though the underlying traffic is genuinely bursty.

Root cause: the **Throughput** and **Error Rate** panels used a `[5m]` rate window. A 5-minute window keeps a single error "alive" on the graph for 5 minutes, so the line never falls back to zero and the spikes get averaged into a persistent ~0.2/s band.

Measured live (30-min window, 1-min buckets) — zero-error buckets by rate window:

| Window | Zero-error buckets | Look |
|---|---|---|
| `[1m]` | 7/31 | spiky, drops to zero ✓ |
| `[2m]` | 2/31 | mostly continuous |
| `[5m]` (was) | 0/31 | never zero — reads as constant errors |

## Change

Switch to `[1m]` on:
- **Throughput** (total + per-service)
- **Error Rate — by Service & Status**

So spikes are visible and errors drop to zero between simulation bursts, and the error bars visibly track the throughput bursts.

Left at `[5m]` (appropriate): latency p95/p50 percentiles, the Error % headline KPI, and the eBPF protocol panel.

## Testing
- Verified the spikiness against live Prometheus (above table).
- Dashboard JSON validated; version bumped 11→12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)