### PR TITLE
CI: gate merges with PR builds; make master builds resilient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,3 +335,29 @@ jobs:
           frontend/playwright-report/
           frontend/test-results/
         retention-days: 30
+
+  # Single aggregate check for branch protection. Require ONLY this context on
+  # master instead of every test + per-service build matrix leg — it stays green
+  # only if all of them pass, and automatically covers services added later.
+  ci-gate:
+    needs:
+      - test-backend
+      - test-frontend
+      - test-go-services
+      - proxymock-validation
+      - build-and-push
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs failed or were cancelled:"
+          echo "  test-backend=${{ needs.test-backend.result }}"
+          echo "  test-frontend=${{ needs.test-frontend.result }}"
+          echo "  test-go-services=${{ needs.test-go-services.result }}"
+          echo "  proxymock-validation=${{ needs.proxymock-validation.result }}"
+          echo "  build-and-push=${{ needs.build-and-push.result }}"
+          exit 1
+      - name: All required checks passed
+        run: echo "All required jobs succeeded."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,17 @@ jobs:
   build-and-push:
     needs: [test-backend, test-frontend, test-go-services]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    
+    # Runs on PRs too (amd64-only, no push) so the image build gates the merge,
+    # and on push to master (full multi-arch, pushed). Platforms/push are set
+    # per-event on the build step below.
+
     permissions:
       contents: read
       packages: write
-    
+
     strategy:
+      # Don't let one service's transient registry flake cancel the other 7.
+      fail-fast: false
       matrix:
         service:
           - user-service
@@ -132,13 +136,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
+    # QEMU is only needed for arm64 emulation, which we only build on master push.
     - name: Set up QEMU
+      if: github.event_name == 'push'
       uses: docker/setup-qemu-action@v3
-    
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    
+
+    # No registry login on PRs — PR builds validate only and do not push.
     - name: Log in to Container Registry
+      if: github.event_name == 'push'
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
@@ -181,11 +189,32 @@ jobs:
           type=ref,event=branch
           type=ref,event=pr
     
+    # PR: build amd64 only, no push (fast merge gate). Master push: full
+    # multi-arch and push to GHCR.
     - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v5
+      continue-on-error: ${{ github.event_name == 'push' }}
+      with:
+        context: ${{
+          matrix.service == 'frontend' && './frontend' ||
+          matrix.service == 'simulation-client' && './simulation-client' ||
+          format('./backend/{0}', matrix.service) }}
+        platforms: ${{ github.event_name == 'push' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+        push: ${{ github.event_name == 'push' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    # Retry once on master to absorb transient GHCR push errors
+    # (e.g. "error writing layer blob: not_found"). Cache makes this fast.
+    - name: Retry build and push (transient registry errors)
+      if: github.event_name == 'push' && steps.build.outcome == 'failure'
       uses: docker/build-push-action@v5
       with:
-        context: ${{ 
-          matrix.service == 'frontend' && './frontend' || 
+        context: ${{
+          matrix.service == 'frontend' && './frontend' ||
           matrix.service == 'simulation-client' && './simulation-client' ||
           format('./backend/{0}', matrix.service) }}
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Problem

Failures keep landing on `master` after merge, and the pipeline is slow. Root causes:

1. **Builds don't gate PRs.** `build-and-push` is `if: github.event_name == 'push'`, so on a PR only the fast tests run. The 8-service multi-arch image build runs **after merge**, on master — so it can't block the merge. A transient GHCR push error (`error writing layer blob: not_found`) then fails master post-merge (this is what broke #115's run).
2. **One flake nukes the run.** The matrix uses default `fail-fast: true`, so one service's transient failure cancels the other 7 and skips the version bump.
3. **It's slow.** Builds target `linux/amd64,linux/arm64` with arm64 emulated via **QEMU** — the long pole.

## Changes

- **Run `build-and-push` on `pull_request`** so the image build gates the merge. PRs build **amd64-only, `push: false`** (skip QEMU + registry login) to keep the gate fast; master push keeps full `linux/amd64,linux/arm64` and pushes.
- **`strategy.fail-fast: false`** — one service's flake no longer cancels the rest or skips versioning.
- **Retry build/push once on master** to absorb transient registry errors; the gha layer cache makes the retry cheap. (`continue-on-error` on the first attempt only on push; on PRs a build failure correctly fails the check.)

`update-k8s-manifests` / `e2e-test` stay master-push-only (skipped on PRs).

## Follow-up (separate, needs admin)
Enable **branch protection** on `master` requiring these checks (`test-backend`, `test-frontend`, `test-go-services`, `proxymock-validation`, and the `build-and-push` matrix contexts) + "branch up to date", so merges block until CI is green. This PR's own run will register the new PR-build contexts so they're selectable. I'll set it up once this lands (or hand you the exact settings).

## Testing
- YAML parses (yq).
- This PR itself exercises the new behavior: `build-and-push` should now run on the PR (amd64-only, no push) and must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)