### PR TITLE
Fix OTel filter so actuator spans are dropped from traces

### DIFF
--- a/kubernetes/observability/otel-collector.yaml
+++ b/kubernetes/observability/otel-collector.yaml
@@ -36,24 +36,28 @@ data:
 
     processors:
       batch: {}
+      # Drop actuator probe/scrape spans and noisy Spring Security internal
+      # spans. Uses OTTL `traces.span` conditions, which are OR-ed: a span is
+      # dropped if ANY condition is true. (The previous MatchProperties form
+      # AND-ed span_names with the attribute list, so it matched nothing and
+      # actuator traces leaked through to Jaeger.)
       filter:
-        spans:
-          exclude:
-            match_type: strict
-            span_names:
-              - "security filterchain before"
-              - "security filterchain after"
-              - "authorize exchange"
-              - "secured request"
-            attributes:
-              - key: http.target
-                value: "/actuator/health"
-              - key: http.target
-                value: "/actuator/prometheus"
-              - key: http.url
-                value: "/actuator/health"
-              - key: http.url
-                value: "/actuator/prometheus"
+        error_mode: ignore
+        traces:
+          span:
+            # Actuator health/liveness/readiness/prometheus probes — match on
+            # span name (e.g. "http get /actuator/health") and on whichever
+            # URL attribute the instrumentation emits.
+            - 'IsMatch(name, "(?i)actuator")'
+            - 'IsMatch(attributes["http.url"], "/actuator")'
+            - 'IsMatch(attributes["http.target"], "/actuator")'
+            - 'IsMatch(attributes["url.path"], "/actuator")'
+            - 'IsMatch(attributes["http.route"], "/actuator")'
+            # Noisy Spring Security internal spans.
+            - 'name == "security filterchain before"'
+            - 'name == "security filterchain after"'
+            - 'name == "authorize exchange"'
+            - 'name == "secured request"'
       attributes/loki-hints:
         actions:
           - key: loki.attribute.labels


### PR DESCRIPTION
## Problem

The Grafana "Recent Traces" widget (and Jaeger generally) is full of `/actuator/health` and `/actuator/prometheus` spans from k8s probes and Prometheus scrapes — they're supposed to be filtered out before reaching Jaeger.

The traces pipeline's `filter` processor used the legacy MatchProperties form with `span_names` **and** an `attributes` list in a single `exclude` block:

```yaml
filter:
  spans:
    exclude:
      match_type: strict
      span_names: [ "security filterchain before", ... ]
      attributes:
        - {key: http.target, value: "/actuator/health"}
        - {key: http.target, value: "/actuator/prometheus"}
        - {key: http.url,    value: "/actuator/health"}
        - {key: http.url,    value: "/actuator/prometheus"}
```

Under MatchProperties these criteria are **AND-ed** (and the attribute list is itself AND-ed), so a span would have to be a "security filterchain" span **and** simultaneously have `http.url` equal to **both** `/actuator/health` and `/actuator/prometheus`. Impossible → the filter matched **nothing**, and every actuator span leaked through.

**Verified live:** `api-gateway` shows operations `http get /actuator/health` / `http get /actuator/prometheus` in Jaeger, with span attribute `http.url=/actuator/health`.

## Fix

Rewrite using OTTL `traces.span` conditions, which are **OR-ed** (drop the span if *any* is true). Collector is `contrib:0.120.0`, which supports OTTL.

```yaml
filter:
  error_mode: ignore
  traces:
    span:
      - 'IsMatch(name, "(?i)actuator")'
      - 'IsMatch(attributes["http.url"], "/actuator")'
      - 'IsMatch(attributes["http.target"], "/actuator")'
      - 'IsMatch(attributes["url.path"], "/actuator")'
      - 'IsMatch(attributes["http.route"], "/actuator")'
      - 'name == "security filterchain before"'   # + the other 3 security spans
```

Matches actuator by span name (e.g. `http get /actuator/health`) **and** by whichever URL attribute the instrumentation emits, so it's robust across services and semconv versions. Health/prometheus traces are single-span (no downstream), so dropping the span removes the trace.

## Deploy note
The `otel-collector` ConfigMap is mounted (not hot-reloaded), so the collector pod must be **restarted** to pick up the new config: `kubectl rollout restart deploy/otel-collector -n banking-app`. Existing actuator traces already in Jaeger age out; the widget clears as new (filtered) traffic flows.

## Testing
- Outer + embedded collector YAML parse (yq).
- OTTL syntax is standard for filterprocessor in 0.120.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)