### PR TITLE
Add Service filter to the banking health dashboard

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -5,9 +5,27 @@
   "tags": ["banking-app", "health", "golden-signals"],
   "editable": true,
   "schemaVersion": 39,
-  "version": 12,
+  "version": 13,
   "time": {"from": "now-30m", "to": "now"},
   "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+        "definition": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)",
+        "query": {"qryType": 1, "query": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "includeAll": true,
+        "multi": true,
+        "allValue": null,
+        "current": {"text": ["All"], "value": ["$__all"]},
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
   "panels": [
     {
       "type": "timeseries",
@@ -38,8 +56,8 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "total req/s", "refId": "A"},
-        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}}", "refId": "B"}
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "total req/s", "refId": "A"},
+        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}}", "refId": "B"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -63,7 +81,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "process_cpu_usage", "legendFormat": "{{job}}", "refId": "A"}
+        {"expr": "process_cpu_usage{job=~\"$service\"}", "legendFormat": "{{job}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -81,8 +99,8 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum by (job) (jvm_memory_used_bytes{area=\"heap\"})", "legendFormat": "{{job}} used", "refId": "A"},
-        {"expr": "sum by (job) (jvm_memory_max_bytes{area=\"heap\"})", "legendFormat": "{{job}} max", "refId": "B"}
+        {"expr": "sum by (job) (jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} used", "refId": "A"},
+        {"expr": "sum by (job) (jvm_memory_max_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} max", "refId": "B"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -105,7 +123,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum by (job, status) (rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}} {{status}}", "refId": "A"}
+        {"expr": "sum by (job, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}} {{status}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -129,7 +147,7 @@
       "gridPos": {"h": 8, "w": 4, "x": 12, "y": 16},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\", uri!~\"/actuator.*\"}[5m])) * 100", "refId": "A"}
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m])) * 100", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
## Why

Two observations on the live dashboard:
- **Throughput** now clearly shows the episodic burst pattern — good.
- **Error Rate — by Service & Status** still reads as noise. Measured live it renders **10 `job × status` series**, most flickering between zero and a tiny value at the `[1m]` window. And **api-gateway double-counts**: as the proxy front door it re-reports every downstream service's 4xx/5xx, so it overlaps the per-service series.

## Change

Add a multi-select **`$service`** template variable (populated from the banking `http_server_requests` jobs) and wire it into the per-service panels:

| Panel | Filtered by `$service`? |
|---|---|
| Throughput | ✅ |
| Saturation — CPU | ✅ |
| Saturation — Memory | ✅ |
| Error Rate — by Service & Status | ✅ |
| Error Rate % | ✅ |
| Latency — Front Door | — (gateway by design) |
| eBPF Protocol / eBPF Error logs | — (namespace / eBPF, no job label) |
| Recent Traces — API Gateway | — (gateway-scoped) |

Picking a single service collapses the error panel from 10 overlapping series to just that service's handful of status codes — which directly de-clutters it. Defaults to **All**.

## Notes
- Variable query is scoped to the four banking Java jobs, so the dropdown never lists other namespaces' services.
- The double-count (api-gateway aggregating downstream errors) is inherent to a front-door proxy; the filter sidesteps it by letting you view one originating service at a time. If you'd prefer, a follow-up could split "front-door errors" (gateway only) from "service errors" (gateway excluded) — say the word.

## Testing
- Dashboard JSON validated; variable definition is non-self-referential; 8 panel queries use `$service`. Version bumped 12→13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)