### PR TITLE
Add 'Errors by Endpoint' panel to surface the failing route (demo beat 2)

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -5,7 +5,7 @@
   "tags": ["banking-app", "health", "golden-signals"],
   "editable": true,
   "schemaVersion": 39,
-  "version": 13,
+  "version": 14,
   "time": {"from": "now-30m", "to": "now"},
   "refresh": "10s",
   "templating": {
@@ -192,9 +192,42 @@
       }
     },
     {
+      "type": "table",
+      "title": "Errors by Endpoint — which route is failing?",
+      "description": "Banking 4xx/5xx broken out by service, HTTP method and route. This is where you spot the failing endpoint — e.g. POST /api/transactions/create returning 400 — that the golden-signal panels only hint at.",
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 24},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job, method, uri, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m]))", "format": "table", "instant": true, "refId": "A"}
+      ],
+      "transformations": [
+        {"id": "organize", "options": {
+          "excludeByName": {"Time": true},
+          "renameByName": {"job": "Service", "method": "Method", "uri": "Endpoint", "status": "Status", "Value": "Errors/sec"}
+        }},
+        {"id": "sortBy", "options": {"fields": {}, "sort": [{"field": "Errors/sec", "desc": true}]}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"align": "auto", "filterable": true, "cellOptions": {"type": "auto"}},
+          "decimals": 3
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Errors/sec"}, "properties": [
+            {"id": "unit", "value": "reqps"},
+            {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+            {"id": "color", "value": {"mode": "continuous-reds"}}
+          ]},
+          {"matcher": {"id": "byName", "options": "Status"}, "properties": [{"id": "custom.width", "value": 90}]},
+          {"matcher": {"id": "byName", "options": "Method"}, "properties": [{"id": "custom.width", "value": 90}]}
+        ]
+      },
+      "options": {"showHeader": true, "cellHeight": "sm", "footer": {"show": false}}
+    },
+    {
       "type": "row",
       "title": "Error Details",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 24},
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 33},
       "collapsed": true,
       "panels": [
         {


### PR DESCRIPTION
## Why

This supports **beat 2** of the demo flow (Grafana golden signals → **spot that create-transaction returns 400** → drill into a trace → Proxymock Web → replicate locally).

The dashboard's golden-signal panels show errors exist and which *service*, but **not which endpoint** — so you can't tell from the dashboard that it's `POST /api/transactions/create` failing. That's the gap: the demo's easter egg is a create-transaction request with an empty required field, which fails `@Valid` in `CreateTransactionRequest` → **400 "Amount is required"** (confirmed in transactions-service logs).

## Change

Add an **"Errors by Endpoint"** table panel that breaks 4xx/5xx down by **service · method · route · status**, sorted by rate, with a red-scale heat on the rate column. It honors the existing `$service` filter.

Verified against live Prometheus — the panel surfaces the easter egg near the top:

```
Service               Method Endpoint                          Status Errors/sec
api-gateway           GET    NOT_FOUND                         404    0.044
transactions-service  POST   /api/transactions/create          400    0.041   ← here
accounts-service      GET    /api/accounts/{accountId}/balance 404    0.041
```

(api-gateway rows show `UNKNOWN` for the route — Spring Cloud Gateway doesn't template the proxied URI — so the **downstream service rows** are what pinpoint the endpoint, which is exactly what you want for the drill-down.)

## Notes
- Placed full-width directly under the error panels; the collapsed "Error Details" row moved down. Version 13→14.
- Beats 3–5 (trace drill-in link, Proxymock Web hand-off, local replay, demo runbook) are intentionally **not** in this PR — left for follow-ups per scope.
- Minor: the injected negative-amount scenario also 400s this endpoint with a *different* message ("Amount must be greater than 0"). If you want the easter egg to be unambiguously the empty-value path, I can make that injection consistent — say the word.

## Testing
- Dashboard JSON validated; panel query validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)