### PR TITLE
Add dashboard drill-down hierarchy

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -1,0 +1,240 @@
+{
+  "annotations": {"list": []},
+  "title": "Banking Application — Errors",
+  "uid": "banking-app-errors",
+  "tags": ["banking-app", "errors"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {"from": "now-30m", "to": "now"},
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+        "definition": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)",
+        "query": {"qryType": 1, "query": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "includeAll": true,
+        "multi": true,
+        "allValue": null,
+        "current": {"text": ["All"], "value": ["$__all"]},
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "links": [
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&var-service=${service}", "targetBlank": false}
+  ],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Total Errors",
+      "description": "Total 4xx + 5xx errors in the selected time range",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(increase(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[30m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 50},
+            {"color": "red", "value": 200}
+          ]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Error %",
+      "description": "Percentage of requests returning 4xx/5xx",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m])) * 100", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 1},
+            {"color": "orange", "value": 3},
+            {"color": "red", "value": 5}
+          ]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "4xx Errors/s",
+      "description": "Client error rate",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"4..\", uri!~\"/actuator.*\"}[1m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "orange", "value": 0.1}
+          ]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "5xx Errors/s",
+      "description": "Server error rate",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"5..\", uri!~\"/actuator.*\"}[1m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "red", "value": 0.01}
+          ]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "timeseries",
+      "title": "Error Rate by Service",
+      "description": "4xx/5xx rate per service over time",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": {"mode": "normal"}},
+          "unit": "reqps"
+        }
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Error Rate by Status Code",
+      "description": "Split by HTTP status code",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{status}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": {"mode": "normal"}},
+          "unit": "reqps"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "^4..$"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byRegexp", "options": "^5..$"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
+        ]
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "table",
+      "title": "Errors by Endpoint",
+      "description": "Which route is failing and why",
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job, method, uri, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m]))", "format": "table", "instant": true, "refId": "A"}
+      ],
+      "transformations": [
+        {"id": "organize", "options": {
+          "excludeByName": {"Time": true},
+          "renameByName": {"job": "Service", "method": "Method", "uri": "Endpoint", "status": "Status", "Value": "Errors/sec"}
+        }},
+        {"id": "sortBy", "options": {"fields": {}, "sort": [{"field": "Errors/sec", "desc": true}]}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"align": "auto", "filterable": true, "cellOptions": {"type": "auto"}},
+          "decimals": 3
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Errors/sec"}, "properties": [
+            {"id": "unit", "value": "reqps"},
+            {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+            {"id": "color", "value": {"mode": "continuous-reds"}}
+          ]},
+          {"matcher": {"id": "byName", "options": "Status"}, "properties": [{"id": "custom.width", "value": 90}]},
+          {"matcher": {"id": "byName", "options": "Method"}, "properties": [{"id": "custom.width", "value": 90}]}
+        ]
+      },
+      "options": {"showHeader": true, "cellHeight": "sm", "footer": {"show": false}}
+    },
+    {
+      "type": "table",
+      "title": "Recent Traces",
+      "description": "Click a trace ID to view spans in Jaeger",
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 21},
+      "datasource": {"type": "jaeger", "uid": "jaeger"},
+      "targets": [
+        {"refId": "A", "datasource": {"type": "jaeger", "uid": "jaeger"}, "queryType": "search", "service": "api-gateway", "operation": "", "tags": "", "minDuration": "", "maxDuration": "", "limit": 20}
+      ],
+      "options": {"showHeader": true, "cellHeight": "sm"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Trace ID"},
+            "properties": [
+              {"id": "links", "value": [
+                {"title": "Open in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22query%22:%22${__value.text}%22}],%22range%22:{%22from%22:%22now-1h%22,%22to%22:%22now%22}}}", "targetBlank": true}
+              ]}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "logs",
+      "title": "eBPF Traffic — Error Requests",
+      "description": "Speedscale eBPF-captured requests returning errors. Full payload inspection requires Speedscale / proxymock.",
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 21},
+      "datasource": {"type": "loki", "uid": "loki"},
+      "targets": [
+        {"expr": "{exporter=\"OTLP\"} |= \"400\" | json | body_status = \"400\" | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    }
+  ]
+}

--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -1,11 +1,11 @@
 {
   "annotations": {"list": []},
-  "title": "Banking Application — Health",
+  "title": "Banking Application — Overview",
   "uid": "banking-app-health",
-  "tags": ["banking-app", "health", "golden-signals"],
+  "tags": ["banking-app", "overview", "golden-signals"],
   "editable": true,
   "schemaVersion": 39,
-  "version": 14,
+  "version": 1,
   "time": {"from": "now-30m", "to": "now"},
   "refresh": "10s",
   "templating": {
@@ -26,125 +26,115 @@
       }
     ]
   },
+  "links": [
+    {"title": "Performance", "icon": "bolt", "type": "link", "url": "/d/banking-app-perf/performance?${__url_time_range}&var-service=${service}", "targetBlank": false},
+    {"title": "Errors", "icon": "exclamation-triangle", "type": "link", "url": "/d/banking-app-errors/errors?${__url_time_range}&var-service=${service}", "targetBlank": false},
+    {"title": "Infrastructure", "icon": "cog", "type": "link", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&var-service=${service}", "targetBlank": false},
+    {"title": "eBPF / BYOC", "icon": "eye", "type": "link", "url": "/d/speedscale-byoc/speedscale-byoc", "targetBlank": false}
+  ],
   "panels": [
     {
-      "type": "timeseries",
-      "title": "Latency — Front Door p95 / p50",
-      "description": "Response time at the API gateway — the user-facing entry point",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "type": "stat",
+      "title": "Latency p95",
+      "description": "95th percentile response time at the API gateway",
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
-        {"expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"api-gateway\"}[5m])))", "legendFormat": "p95", "refId": "A"},
-        {"expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"api-gateway\"}[5m])))", "legendFormat": "p50", "refId": "B"}
+        {"expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"api-gateway\"}[5m])))", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "pointSize": 5, "showPoints": "never"},
           "unit": "s",
-          "color": {"mode": "palette-classic"}
-        },
-        "overrides": [
-          {"matcher": {"id": "byName", "options": "p95"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
-          {"matcher": {"id": "byName", "options": "p50"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]}
-        ]
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Throughput — Requests / sec",
-      "description": "HTTP request rate per banking service (Spring http_server_requests; actuator/health excluded). Banking-app namespace only.",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
-      "targets": [
-        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "total req/s", "refId": "A"},
-        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}}", "refId": "B"}
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 1, "stacking": {"mode": "normal"}},
-          "unit": "reqps"
-        },
-        "overrides": [
-          {"matcher": {"id": "byName", "options": "total req/s"}, "properties": [
-            {"id": "custom.stacking", "value": {"mode": "none"}},
-            {"id": "custom.lineWidth", "value": 3},
-            {"id": "custom.fillOpacity", "value": 0},
-            {"id": "color", "value": {"fixedColor": "white", "mode": "fixed"}}
-          ]}
-        ]
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Saturation — CPU",
-      "description": "Process CPU utilization per service (0–1 = one core)",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
-      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
-      "targets": [
-        {"expr": "process_cpu_usage{job=~\"$service\"}", "legendFormat": "{{job}}", "refId": "A"}
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 1},
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 0.3},
+            {"color": "orange", "value": 0.5},
+            {"color": "red", "value": 1}
+          ]},
+          "color": {"mode": "thresholds"},
+          "links": [{"title": "Drill down → Performance", "url": "/d/banking-app-perf/performance?${__url_time_range}&var-service=${service}"}]
         }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Saturation — Memory",
-      "description": "JVM heap used vs max per service",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
-      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
-      "targets": [
-        {"expr": "sum by (job) (jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} used", "refId": "A"},
-        {"expr": "sum by (job) (jvm_memory_max_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} max", "refId": "B"}
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 1},
-          "unit": "bytes"
-        },
-        "overrides": [
-          {"matcher": {"id": "byRegexp", "options": ".* max"}, "properties": [
-            {"id": "custom.lineStyle", "value": {"fill": "dash", "dash": [10, 10]}},
-            {"id": "custom.fillOpacity", "value": 0},
-            {"id": "custom.lineWidth", "value": 1}
-          ]}
-        ]
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Error Rate — by Service & Status",
-      "description": "Banking-app HTTP 4xx/5xx by service and status code (Spring http_server_requests; actuator/health excluded).",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
-      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
-      "targets": [
-        {"expr": "sum by (job, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}} {{status}}", "refId": "A"}
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "stacking": {"mode": "normal"}},
-          "unit": "reqps",
-          "links": [
-            {"title": "View traces in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22queryType%22:%22search%22,%22limit%22:20}],%22range%22:{%22from%22:%22now-30m%22,%22to%22:%22now%22}}}", "targetBlank": true}
-          ]
-        },
-        "overrides": [
-          {"matcher": {"id": "byRegexp", "options": ".*400$"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
-          {"matcher": {"id": "byRegexp", "options": ".*5[0-9]{2}$"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
-        ]
       },
-      "options": {"tooltip": {"mode": "multi"}}
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
     },
     {
       "type": "stat",
-      "title": "Error Rate %",
-      "description": "Percentage of banking-app requests returning 4xx/5xx (actuator/health excluded).",
-      "gridPos": {"h": 8, "w": 4, "x": 12, "y": 16},
+      "title": "Throughput",
+      "description": "Total HTTP request rate across banking services",
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "blue", "value": null}
+          ]},
+          "color": {"mode": "thresholds"},
+          "links": [{"title": "Drill down → Performance", "url": "/d/banking-app-perf/performance?${__url_time_range}&var-service=${service}"}]
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "CPU",
+      "description": "Peak process CPU across banking services",
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "max(process_cpu_usage{job=~\"$service\"})", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 0.5},
+            {"color": "orange", "value": 0.7},
+            {"color": "red", "value": 0.9}
+          ]},
+          "color": {"mode": "thresholds"},
+          "links": [{"title": "Drill down → Infrastructure", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&var-service=${service}"}]
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Memory",
+      "description": "JVM heap utilization (used / max) across all services",
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"}) / sum(jvm_memory_max_bytes{area=\"heap\", job=~\"$service\"})", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 0.6},
+            {"color": "orange", "value": 0.8},
+            {"color": "red", "value": 0.9}
+          ]},
+          "color": {"mode": "thresholds"},
+          "links": [{"title": "Drill down → Infrastructure", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&var-service=${service}"}]
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Error %",
+      "description": "Percentage of requests returning 4xx/5xx",
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
         {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m])) * 100", "refId": "A"}
@@ -153,25 +143,75 @@
         "defaults": {
           "unit": "percent",
           "decimals": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 1},
-              {"color": "orange", "value": 3},
-              {"color": "red", "value": 5}
-            ]
-          },
-          "color": {"mode": "thresholds"}
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 1},
+            {"color": "orange", "value": 3},
+            {"color": "red", "value": 5}
+          ]},
+          "color": {"mode": "thresholds"},
+          "links": [{"title": "Drill down → Errors", "url": "/d/banking-app-errors/errors?${__url_time_range}&var-service=${service}"}]
         }
       },
-      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}}
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "eBPF msg/s",
+      "description": "Speedscale eBPF capture rate for banking-app namespace",
+      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sum(rate(messages_sent_total{component=\"forwarder\", k8sAppPodNamespace=\"banking-app\"}[5m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "purple", "value": null}
+          ]},
+          "color": {"mode": "thresholds"},
+          "links": [{"title": "Drill down → eBPF / BYOC", "url": "/d/speedscale-byoc/speedscale-byoc"}]
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
     },
     {
       "type": "timeseries",
-      "title": "eBPF Capture — Messages by Protocol",
-      "description": "Speedscale eBPF capture rate by protocol for the banking-app namespace. Shows HTTP, Postgres, MongoDB, Kafka, Redis, gRPC traffic flowing through the pipeline.",
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 16},
+      "title": "Request Rate + Errors",
+      "description": "Total throughput with error traffic overlaid",
+      "gridPos": {"h": 8, "w": 14, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "total req/s", "refId": "A"},
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "errors/s", "refId": "B"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "pointSize": 5, "showPoints": "never"},
+          "unit": "reqps"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "total req/s"}, "properties": [
+            {"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}},
+            {"id": "custom.fillOpacity", "value": 15}
+          ]},
+          {"matcher": {"id": "byName", "options": "errors/s"}, "properties": [
+            {"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}},
+            {"id": "custom.drawStyle", "value": "bars"},
+            {"id": "custom.fillOpacity", "value": 80},
+            {"id": "custom.lineWidth", "value": 0}
+          ]}
+        ]
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "eBPF Capture by Protocol",
+      "description": "Speedscale eBPF capture rate by protocol",
+      "gridPos": {"h": 8, "w": 10, "x": 14, "y": 4},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
         {"expr": "sum by (protocol) (rate(messages_sent_total{component=\"forwarder\", k8sAppPodNamespace=\"banking-app\"}[5m]))", "legendFormat": "{{protocol}}", "refId": "A"}
@@ -193,9 +233,9 @@
     },
     {
       "type": "table",
-      "title": "Errors by Endpoint — which route is failing?",
-      "description": "Banking 4xx/5xx broken out by service, HTTP method and route. This is where you spot the failing endpoint — e.g. POST /api/transactions/create returning 400 — that the golden-signal panels only hint at.",
-      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 24},
+      "title": "Errors by Endpoint",
+      "description": "Which route is failing? Click Error % header to drill down.",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 12},
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
         {"expr": "sum by (job, method, uri, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m]))", "format": "table", "instant": true, "refId": "A"}
@@ -210,7 +250,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {"align": "auto", "filterable": true, "cellOptions": {"type": "auto"}},
-          "decimals": 3
+          "decimals": 3,
+          "links": [{"title": "View in Errors dashboard", "url": "/d/banking-app-errors/errors?${__url_time_range}&var-service=${__data.fields.Service}"}]
         },
         "overrides": [
           {"matcher": {"id": "byName", "options": "Errors/sec"}, "properties": [
@@ -223,61 +264,6 @@
         ]
       },
       "options": {"showHeader": true, "cellHeight": "sm", "footer": {"show": false}}
-    },
-    {
-      "type": "row",
-      "title": "Error Details",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 33},
-      "collapsed": true,
-      "panels": [
-        {
-          "type": "table",
-          "title": "Recent Traces — API Gateway",
-          "description": "Click a trace to see spans. Spans show timing and status — not payloads.",
-          "gridPos": {"h": 10, "w": 12, "x": 0, "y": 25},
-          "datasource": {"type": "jaeger", "uid": "jaeger"},
-          "targets": [
-            {"refId": "A", "datasource": {"type": "jaeger", "uid": "jaeger"}, "queryType": "search", "service": "api-gateway", "operation": "", "tags": "", "minDuration": "", "maxDuration": "", "limit": 20}
-          ],
-          "options": {"showHeader": true, "cellHeight": "sm"},
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": [
-              {
-                "matcher": {"id": "byName", "options": "Trace ID"},
-                "properties": [
-                  {
-                    "id": "links",
-                    "value": [
-                      {"title": "Open in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22query%22:%22${__value.text}%22}],%22range%22:{%22from%22:%22now-1h%22,%22to%22:%22now%22}}}", "targetBlank": true}
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "type": "logs",
-          "title": "eBPF Traffic — Error Requests",
-          "description": "Structured traffic records from Speedscale eBPF capture. Service, status, endpoint, duration — metadata only, not request/response payloads. Open Speedscale for full payload inspection.",
-          "gridPos": {"h": 10, "w": 12, "x": 12, "y": 25},
-          "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [
-            {"expr": "{exporter=\"OTLP\"} |= \"400\" | json | body_status = \"400\" | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
-          ],
-          "options": {
-            "showTime": true,
-            "showLabels": false,
-            "showCommonLabels": false,
-            "wrapLogMessage": false,
-            "prettifyLogMessage": false,
-            "enableLogDetails": true,
-            "sortOrder": "Descending",
-            "dedupStrategy": "none"
-          }
-        }
-      ]
     }
   ]
 }

--- a/kubernetes/observability/dashboards/banking-app-infra.json
+++ b/kubernetes/observability/dashboards/banking-app-infra.json
@@ -1,0 +1,239 @@
+{
+  "annotations": {"list": []},
+  "title": "Banking Application — Infrastructure",
+  "uid": "banking-app-infra",
+  "tags": ["banking-app", "infrastructure", "resources"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {"from": "now-30m", "to": "now"},
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+        "definition": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)",
+        "query": {"qryType": 1, "query": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "includeAll": true,
+        "multi": true,
+        "allValue": null,
+        "current": {"text": ["All"], "value": ["$__all"]},
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "links": [
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&var-service=${service}", "targetBlank": false}
+  ],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Peak CPU",
+      "description": "Highest process CPU across services",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "max(process_cpu_usage{job=~\"$service\"})", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit", "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.5}, {"color": "red", "value": 0.9}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Heap Used",
+      "description": "Total JVM heap in use across all services",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"})", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes", "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "GC Overhead",
+      "description": "Maximum GC overhead across services",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "max(jvm_gc_overhead_percent{job=~\"$service\"})", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}, {"color": "red", "value": 15}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "DB Connections",
+      "description": "Total active HikariCP connections",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(hikaricp_connections_active{job=~\"$service\"})", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short", "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 8}, {"color": "red", "value": 10}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU by Service",
+      "description": "Process CPU utilization per service (0-1 = one core)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "process_cpu_usage{job=~\"$service\"}", "legendFormat": "{{job}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "showPoints": "never"},
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": {"mode": "palette-classic"}
+        }
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Memory by Service — Heap Used vs Max",
+      "description": "JVM heap used (solid) vs max (dashed) per service",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job) (jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} used", "refId": "A"},
+        {"expr": "sum by (job) (jvm_memory_max_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} max", "refId": "B"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never"},
+          "unit": "bytes"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".* max"}, "properties": [
+            {"id": "custom.lineStyle", "value": {"fill": "dash", "dash": [10, 10]}},
+            {"id": "custom.fillOpacity", "value": 0},
+            {"id": "custom.lineWidth", "value": 1}
+          ]}
+        ]
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "GC Pause Duration",
+      "description": "Garbage collection pause rate per service",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "rate(jvm_gc_pause_seconds_sum{job=~\"$service\"}[5m])", "legendFormat": "{{job}} {{action}} {{cause}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 1, "showPoints": "never"},
+          "unit": "s",
+          "color": {"mode": "palette-classic"}
+        }
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Connection Pools",
+      "description": "HikariCP and JDBC connection states",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "hikaricp_connections_active{job=~\"$service\"}", "legendFormat": "{{job}} active", "refId": "A"},
+        {"expr": "hikaricp_connections_idle{job=~\"$service\"}", "legendFormat": "{{job}} idle", "refId": "B"},
+        {"expr": "hikaricp_connections_max{job=~\"$service\"}", "legendFormat": "{{job}} max", "refId": "C"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never"},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".* max"}, "properties": [
+            {"id": "custom.lineStyle", "value": {"fill": "dash", "dash": [10, 10]}},
+            {"id": "custom.fillOpacity", "value": 0}
+          ]},
+          {"matcher": {"id": "byRegexp", "options": ".* idle"}, "properties": [
+            {"id": "custom.fillOpacity", "value": 5}
+          ]}
+        ]
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM Threads",
+      "description": "Live thread count per service",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "jvm_threads_live_threads{job=~\"$service\"}", "legendFormat": "{{job}} live", "refId": "A"},
+        {"expr": "jvm_threads_peak_threads{job=~\"$service\"}", "legendFormat": "{{job}} peak", "refId": "B"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never"},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".* peak"}, "properties": [
+            {"id": "custom.lineStyle", "value": {"fill": "dash", "dash": [10, 10]}},
+            {"id": "custom.fillOpacity", "value": 0}
+          ]}
+        ]
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Loaded Classes",
+      "description": "JVM loaded class count per service",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "jvm_classes_loaded_classes{job=~\"$service\"}", "legendFormat": "{{job}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never"},
+          "unit": "short",
+          "color": {"mode": "palette-classic"}
+        }
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    }
+  ]
+}

--- a/kubernetes/observability/dashboards/banking-app-perf.json
+++ b/kubernetes/observability/dashboards/banking-app-perf.json
@@ -1,0 +1,228 @@
+{
+  "annotations": {"list": []},
+  "title": "Banking Application — Performance",
+  "uid": "banking-app-perf",
+  "tags": ["banking-app", "performance", "latency"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {"from": "now-30m", "to": "now"},
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+        "definition": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)",
+        "query": {"qryType": 1, "query": "label_values(http_server_requests_seconds_count{job=~\"api-gateway|accounts-service|transactions-service|user-service\"}, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "includeAll": true,
+        "multi": true,
+        "allValue": null,
+        "current": {"text": ["All"], "value": ["$__all"]},
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "links": [
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&var-service=${service}", "targetBlank": false}
+  ],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Latency p95",
+      "description": "95th percentile at the API gateway",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"api-gateway\"}[5m])))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s", "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.3}, {"color": "red", "value": 1}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Latency p50",
+      "description": "Median response time at the API gateway",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"api-gateway\"}[5m])))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s", "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.2}, {"color": "red", "value": 0.5}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Throughput",
+      "description": "Total request rate",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps", "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "stat",
+      "title": "Avg Duration",
+      "description": "Average request duration across all services",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum(rate(http_server_requests_seconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s", "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.1}, {"color": "red", "value": 0.5}]},
+          "color": {"mode": "thresholds"}
+        }
+      },
+      "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency by Service — p95",
+      "description": "95th percentile response time per service",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le, job) (rate(http_server_requests_seconds_bucket{job=~\"$service\", uri!~\"/actuator.*\"}[5m])))", "legendFormat": "{{job}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "unit": "s",
+          "color": {"mode": "palette-classic"}
+        }
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Throughput by Service",
+      "description": "Request rate per service (stacked)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))", "legendFormat": "{{job}}", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 1, "stacking": {"mode": "normal"}},
+          "unit": "reqps"
+        }
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "type": "table",
+      "title": "Latency by Endpoint",
+      "description": "Average and p95 latency per endpoint",
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job, uri) (rate(http_server_requests_seconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m])) / sum by (job, uri) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))", "format": "table", "instant": true, "refId": "A"}
+      ],
+      "transformations": [
+        {"id": "organize", "options": {
+          "excludeByName": {"Time": true},
+          "renameByName": {"job": "Service", "uri": "Endpoint", "Value": "Avg Latency"}
+        }},
+        {"id": "sortBy", "options": {"fields": {}, "sort": [{"field": "Avg Latency", "desc": true}]}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"align": "auto", "filterable": true},
+          "decimals": 3
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Avg Latency"}, "properties": [
+            {"id": "unit", "value": "s"},
+            {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+            {"id": "color", "value": {"mode": "continuous-blues"}}
+          ]}
+        ]
+      },
+      "options": {"showHeader": true, "cellHeight": "sm", "footer": {"show": false}}
+    },
+    {
+      "type": "table",
+      "title": "Throughput by Endpoint",
+      "description": "Request rate per endpoint",
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus-app"},
+      "targets": [
+        {"expr": "sum by (job, method, uri) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))", "format": "table", "instant": true, "refId": "A"}
+      ],
+      "transformations": [
+        {"id": "organize", "options": {
+          "excludeByName": {"Time": true},
+          "renameByName": {"job": "Service", "method": "Method", "uri": "Endpoint", "Value": "Req/sec"}
+        }},
+        {"id": "sortBy", "options": {"fields": {}, "sort": [{"field": "Req/sec", "desc": true}]}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"align": "auto", "filterable": true},
+          "decimals": 3
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Req/sec"}, "properties": [
+            {"id": "unit", "value": "reqps"},
+            {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+            {"id": "color", "value": {"mode": "continuous-greens"}}
+          ]},
+          {"matcher": {"id": "byName", "options": "Method"}, "properties": [{"id": "custom.width", "value": 90}]}
+        ]
+      },
+      "options": {"showHeader": true, "cellHeight": "sm", "footer": {"show": false}}
+    },
+    {
+      "type": "table",
+      "title": "Recent Traces",
+      "description": "Click a trace ID to view spans in Jaeger",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 21},
+      "datasource": {"type": "jaeger", "uid": "jaeger"},
+      "targets": [
+        {"refId": "A", "datasource": {"type": "jaeger", "uid": "jaeger"}, "queryType": "search", "service": "api-gateway", "operation": "", "tags": "", "minDuration": "", "maxDuration": "", "limit": 20}
+      ],
+      "options": {"showHeader": true, "cellHeight": "sm"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Trace ID"},
+            "properties": [
+              {"id": "links", "value": [
+                {"title": "Open in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22query%22:%22${__value.text}%22}],%22range%22:{%22from%22:%22now-1h%22,%22to%22:%22now%22}}}", "targetBlank": true}
+              ]}
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubernetes/observability/kustomization.yaml
+++ b/kubernetes/observability/kustomization.yaml
@@ -22,6 +22,9 @@ configMapGenerator:
     namespace: banking-app
     files:
       - banking-app-health.json=dashboards/banking-app-health.json
+      - banking-app-errors.json=dashboards/banking-app-errors.json
+      - banking-app-perf.json=dashboards/banking-app-perf.json
+      - banking-app-infra.json=dashboards/banking-app-infra.json
   - name: grafana-dashboards-byoc
     namespace: banking-app
     files:


### PR DESCRIPTION
## Summary
- Redesigned overview dashboard with 6 dense stat widgets (latency, throughput, CPU, memory, error %, eBPF msg/s) linking to drill-down dashboards
- Added Errors dashboard — errors by app, by endpoint, traces, and eBPF error logs
- Added Performance dashboard — latency/throughput by service and endpoint, traces
- Added Infrastructure dashboard — CPU, memory, GC, connection pools, JVM threads

## Test plan
- [x] All 4 dashboards previewed live on apex-grafana.trafficreplay.com
- [x] JSON validated
- [x] Drill-down links verified working
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)