### PR TITLE
Organize Grafana dashboard folders and set home

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -27,7 +27,7 @@
     ]
   },
   "links": [
-    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&var-service=${service}", "targetBlank": false}
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&${__all_variables}", "targetBlank": false}
   ],
   "panels": [
     {

--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -27,9 +27,9 @@
     ]
   },
   "links": [
-    {"title": "Performance", "icon": "bolt", "type": "link", "url": "/d/banking-app-perf/performance?${__url_time_range}&var-service=${service}", "targetBlank": false},
-    {"title": "Errors", "icon": "exclamation-triangle", "type": "link", "url": "/d/banking-app-errors/errors?${__url_time_range}&var-service=${service}", "targetBlank": false},
-    {"title": "Infrastructure", "icon": "cog", "type": "link", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&var-service=${service}", "targetBlank": false},
+    {"title": "Performance", "icon": "bolt", "type": "link", "url": "/d/banking-app-perf/performance?${__url_time_range}&${__all_variables}", "targetBlank": false},
+    {"title": "Errors", "icon": "exclamation-triangle", "type": "link", "url": "/d/banking-app-errors/errors?${__url_time_range}&${__all_variables}", "targetBlank": false},
+    {"title": "Infrastructure", "icon": "cog", "type": "link", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&${__all_variables}", "targetBlank": false},
     {"title": "eBPF / BYOC", "icon": "eye", "type": "link", "url": "/d/speedscale-byoc/speedscale-byoc", "targetBlank": false}
   ],
   "panels": [
@@ -53,7 +53,7 @@
             {"color": "red", "value": 1}
           ]},
           "color": {"mode": "thresholds"},
-          "links": [{"title": "Drill down → Performance", "url": "/d/banking-app-perf/performance?${__url_time_range}&var-service=${service}"}]
+          "links": [{"title": "Drill down → Performance", "url": "/d/banking-app-perf/performance?${__url_time_range}&${__all_variables}"}]
         }
       },
       "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
@@ -75,7 +75,7 @@
             {"color": "blue", "value": null}
           ]},
           "color": {"mode": "thresholds"},
-          "links": [{"title": "Drill down → Performance", "url": "/d/banking-app-perf/performance?${__url_time_range}&var-service=${service}"}]
+          "links": [{"title": "Drill down → Performance", "url": "/d/banking-app-perf/performance?${__url_time_range}&${__all_variables}"}]
         }
       },
       "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
@@ -100,7 +100,7 @@
             {"color": "red", "value": 0.9}
           ]},
           "color": {"mode": "thresholds"},
-          "links": [{"title": "Drill down → Infrastructure", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&var-service=${service}"}]
+          "links": [{"title": "Drill down → Infrastructure", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&${__all_variables}"}]
         }
       },
       "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
@@ -125,7 +125,7 @@
             {"color": "red", "value": 0.9}
           ]},
           "color": {"mode": "thresholds"},
-          "links": [{"title": "Drill down → Infrastructure", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&var-service=${service}"}]
+          "links": [{"title": "Drill down → Infrastructure", "url": "/d/banking-app-infra/infrastructure?${__url_time_range}&${__all_variables}"}]
         }
       },
       "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}
@@ -150,7 +150,7 @@
             {"color": "red", "value": 5}
           ]},
           "color": {"mode": "thresholds"},
-          "links": [{"title": "Drill down → Errors", "url": "/d/banking-app-errors/errors?${__url_time_range}&var-service=${service}"}]
+          "links": [{"title": "Drill down → Errors", "url": "/d/banking-app-errors/errors?${__url_time_range}&${__all_variables}"}]
         }
       },
       "options": {"graphMode": "area", "textMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"}

--- a/kubernetes/observability/dashboards/banking-app-infra.json
+++ b/kubernetes/observability/dashboards/banking-app-infra.json
@@ -27,7 +27,7 @@
     ]
   },
   "links": [
-    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&var-service=${service}", "targetBlank": false}
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&${__all_variables}", "targetBlank": false}
   ],
   "panels": [
     {

--- a/kubernetes/observability/dashboards/banking-app-perf.json
+++ b/kubernetes/observability/dashboards/banking-app-perf.json
@@ -27,7 +27,7 @@
     ]
   },
   "links": [
-    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&var-service=${service}", "targetBlank": false}
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&${__all_variables}", "targetBlank": false}
   ],
   "panels": [
     {

--- a/kubernetes/observability/grafana.yaml
+++ b/kubernetes/observability/grafana.yaml
@@ -57,6 +57,14 @@ data:
         editable: true
         options:
           path: /var/lib/grafana/dashboards/app
+      - name: banking-app-details
+        orgId: 1
+        folder: 'Banking App — Drilldowns'
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/app-details
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -94,6 +102,8 @@ spec:
               value: "true"
             - name: GF_SERVER_ROOT_URL
               value: https://apex-grafana.trafficreplay.com
+            - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+              value: /var/lib/grafana/dashboards/app/banking-app-health.json
           volumeMounts:
             - name: data
               mountPath: /var/lib/grafana
@@ -105,6 +115,8 @@ spec:
               mountPath: /var/lib/grafana/dashboards/byoc
             - name: dashboards-app
               mountPath: /var/lib/grafana/dashboards/app
+            - name: dashboards-app-details
+              mountPath: /var/lib/grafana/dashboards/app-details
           resources:
             requests:
               cpu: 100m
@@ -132,6 +144,9 @@ spec:
         - name: dashboards-app
           configMap:
             name: grafana-dashboards-app
+        - name: dashboards-app-details
+          configMap:
+            name: grafana-dashboards-app-details
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/observability/kustomization.yaml
+++ b/kubernetes/observability/kustomization.yaml
@@ -22,6 +22,9 @@ configMapGenerator:
     namespace: banking-app
     files:
       - banking-app-health.json=dashboards/banking-app-health.json
+  - name: grafana-dashboards-app-details
+    namespace: banking-app
+    files:
       - banking-app-errors.json=dashboards/banking-app-errors.json
       - banking-app-perf.json=dashboards/banking-app-perf.json
       - banking-app-infra.json=dashboards/banking-app-infra.json


### PR DESCRIPTION
## Summary
- Split Banking App dashboards into two provisioned folders: "Banking App" (Overview only) and "Banking App — Drilldowns" (Errors, Infrastructure, Performance)
- Set Overview as the Grafana home dashboard via `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH`
- Landing on Grafana now shows the Overview with its stat widgets and navigation links to each drilldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)