### PR TITLE
Wire AI chat to Speedscale responder (no live API key)

### DIFF
--- a/frontend/src/app/api/ai/chat/route.ts
+++ b/frontend/src/app/api/ai/chat/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 
 const AI_API_KEY = process.env.AI_API_KEY || '';
-const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
 const MODEL = 'claude-sonnet-4-20250514';
 const SYSTEM_PROMPT = 'You are a helpful banking assistant. Answer questions about the user\'s accounts and transactions. Be concise.';
 

--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -149,6 +149,10 @@ data:
   # name here makes every /api/* call fail with ENOTFOUND -> HTTP 500.
   API_GATEWAY_URL: "http://banking-gateway:80"
   BACKEND_API_URL: "http://banking-gateway:80"
+
+  # AI chat — point at the Speedscale responder serving mock Anthropic responses.
+  # The responder accepts any API key and returns pre-recorded LLM responses.
+  ANTHROPIC_API_URL: "http://speedscale-responder-banking-frontend-anthropic-mock:4145/v1/messages"
   
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "frontend"

--- a/kubernetes/base/deployments/anthropic-responder.yaml
+++ b/kubernetes/base/deployments/anthropic-responder.yaml
@@ -1,0 +1,23 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: anthropic-mock
+  namespace: banking-app
+spec:
+  mode: responder-only
+  snapshotID: "d4a02604-5854-41ec-964d-83a4fae3aeda"
+  testConfigID: "decoy-mock"
+  cleanup: inventory
+  workloadRef:
+    kind: Deployment
+    name: banking-frontend
+  workloads:
+    - ref:
+        kind: Deployment
+        name: banking-frontend
+        namespace: banking-app
+      mocks:
+        - "*"
+  sidecar:
+    tls:
+      out: true

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
   - deployments/frontend-deployment.yaml
   - deployments/simulation-client-deployment.yaml
   - deployments/simulation-client-hpa.yaml
+  - deployments/anthropic-responder.yaml
 
   # Microservice Services
   - services/user-service-service.yaml


### PR DESCRIPTION
## Summary
- Make `ANTHROPIC_API_URL` configurable via env var in `route.ts` (was hardcoded to `api.anthropic.com`)
- Add `ANTHROPIC_API_URL` to `banking-frontend-config` ConfigMap pointing at the responder service
- Add `TrafficReplay` CR (`anthropic-mock`) using DLP-scrubbed snapshot `d4a02604` in responder-only mode
- The dummy key `sk-ant-mock-key-served-by-speedscale-responder` in `ai-secret.yaml` now works as intended

**Note:** The original snapshot `56247013` had an unredacted `x-api-key` header — the `standard` DLP config only covers `authorization`, not `x-api-key`. This PR uses a cloned snapshot with the key manually scrubbed. The original key should be revoked on the Anthropic console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)