### PR TITLE
Add ai-service to version bump script

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -7,7 +7,7 @@ set -e
 
 VERSION_FILE="VERSION"
 REGISTRY="ghcr.io/speedscale/microsvc"
-SERVICES=("user-service" "accounts-service" "transactions-service" "api-gateway" "frontend" "simulation-client" "fraud-service" "notification-service")
+SERVICES=("user-service" "accounts-service" "transactions-service" "api-gateway" "ai-service" "frontend" "simulation-client" "fraud-service" "notification-service")
 BACKEND_SERVICES=("user-service" "accounts-service" "transactions-service" "api-gateway")
 FRONTEND_SERVICES=("frontend")
 SIMULATION_SERVICES=("simulation-client")


### PR DESCRIPTION
ai-service was missing from the SERVICES array in scripts/version.sh, so `make update-k8s-version` never bumped ai-service-deployment.yaml. This caused ImagePullBackOff on dev-decoy — the tag stayed at v1.4.18 while everything else bumped to v1.4.19.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>