### PR TITLE
Add ai-service to Speedscale eBPF capture overlay

### DIFF
--- a/kubernetes/overlays/speedscale/ai-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/ai-service-annotations.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: banking-ai
+  namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "false"
+    capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/kustomization.yaml
+++ b/kubernetes/overlays/speedscale/kustomization.yaml
@@ -21,6 +21,7 @@ patches:
 - path: user-service-annotations.yaml
 - path: accounts-service-annotations.yaml
 - path: transactions-service-annotations.yaml
+- path: ai-service-annotations.yaml
 - path: api-gateway-annotations.yaml
 - path: frontend-annotations.yaml
 - path: simulation-client-annotations.yaml


### PR DESCRIPTION
ai-service was missing from the Speedscale kustomize overlay — no capture annotations meant the operator skipped it for eBPF instrumentation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>