### PR TITLE
Enable JVMTI java-agent on Java services for eBPF TLS capture

### DIFF
--- a/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"
+    capture.speedscale.com/java-agent: "true"

--- a/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
+++ b/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"
+    capture.speedscale.com/java-agent: "true"

--- a/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"
+    capture.speedscale.com/java-agent: "true"


### PR DESCRIPTION
Adds `capture.speedscale.com/java-agent: "true"` to accounts-service, transactions-service, and api-gateway. Without this the operator never injects the JVMTI agent, so nettap can't see outbound HTTPS from JVM services (Stripe, PayPal, Plaid, Socure, etc.).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>