### PR TITLE
Move observability stack to dedicated namespace

### DIFF
--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -22,7 +22,7 @@ data:
   KAFKA_BROKERS: "banking-kafka:9092"
 
   # Observability (language-agnostic OTel)
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"
@@ -45,7 +45,7 @@ data:
   DB_SCHEMA: "user_service"
   SERVER_PORT: "8080"
   OTEL_SERVICE_NAME: "user-service"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"
@@ -74,7 +74,7 @@ data:
   LOGGING_LEVEL_COM_BANKING: "DEBUG"
   LOGGING_LEVEL_IO_OPENTELEMETRY: "DEBUG"
   OTEL_SERVICE_NAME: "accounts-service"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"
@@ -103,7 +103,7 @@ data:
   LOGGING_LEVEL_COM_BANKING: "DEBUG"
   LOGGING_LEVEL_IO_OPENTELEMETRY: "DEBUG"
   OTEL_SERVICE_NAME: "transactions-service"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"
@@ -132,7 +132,7 @@ data:
   LOGGING_LEVEL_COM_BANKING: "DEBUG"
   LOGGING_LEVEL_IO_OPENTELEMETRY: "DEBUG"
   OTEL_SERVICE_NAME: "api-gateway"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"
@@ -159,7 +159,7 @@ data:
   
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "frontend"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318/v1/traces"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4318/v1/traces"
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"

--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -56,7 +56,7 @@ data:
 
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "simulation-client"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"

--- a/kubernetes/observability/grafana.yaml
+++ b/kubernetes/observability/grafana.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-datasources
-  namespace: banking-app
+  namespace: observability
 data:
   datasources.yaml: |
     apiVersion: 1
@@ -36,7 +36,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-providers
-  namespace: banking-app
+  namespace: observability
 data:
   providers.yaml: |
     apiVersion: 1
@@ -70,7 +70,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: banking-app
+  namespace: observability
   labels:
     app: grafana
 spec:
@@ -152,7 +152,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: banking-app
+  namespace: observability
 spec:
   selector:
     app: grafana

--- a/kubernetes/observability/jaeger-deployment.yaml
+++ b/kubernetes/observability/jaeger-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger
-  namespace: banking-app
+  namespace: observability
   labels:
     app: jaeger
 spec:
@@ -58,7 +58,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jaeger
-  namespace: banking-app
+  namespace: observability
   labels:
     app: jaeger
 spec:

--- a/kubernetes/observability/kustomization.yaml
+++ b/kubernetes/observability/kustomization.yaml
@@ -2,10 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 metadata:
-  name: banking-app-observability
-  namespace: banking-app
+  name: observability
+
+namespace: observability
 
 resources:
+  - namespace.yaml
   - prometheus-deployment.yaml
   - prometheus-config.yaml
   - otel-collector.yaml
@@ -18,18 +20,15 @@ generatorOptions:
 
 configMapGenerator:
   - name: grafana-dashboards-app
-    namespace: banking-app
     files:
       - banking-app-health.json=dashboards/banking-app-health.json
       - banking-app-architecture.json=dashboards/banking-app-architecture.json
   - name: grafana-dashboards-app-details
-    namespace: banking-app
     files:
       - banking-app-errors.json=dashboards/banking-app-errors.json
       - banking-app-perf.json=dashboards/banking-app-perf.json
       - banking-app-infra.json=dashboards/banking-app-infra.json
   - name: grafana-dashboards-byoc
-    namespace: banking-app
     files:
       - speedscale-byoc.json=dashboards/speedscale-byoc.json
       - speedscale-traffic.json=dashboards/speedscale-traffic.json

--- a/kubernetes/observability/loki.yaml
+++ b/kubernetes/observability/loki.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: loki-config
-  namespace: banking-app
+  namespace: observability
 data:
   loki.yaml: |
     auth_enabled: false
@@ -51,7 +51,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loki
-  namespace: banking-app
+  namespace: observability
   labels:
     app: loki
 spec:
@@ -94,7 +94,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: loki
-  namespace: banking-app
+  namespace: observability
 spec:
   selector:
     app: loki

--- a/kubernetes/observability/namespace.yaml
+++ b/kubernetes/observability/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+  labels:
+    name: observability

--- a/kubernetes/observability/otel-collector.yaml
+++ b/kubernetes/observability/otel-collector.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: otel-collector-conf
-  namespace: banking-app
+  namespace: observability
 data:
   otel-collector-config.yaml: |
     receivers:
@@ -144,7 +144,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: otel-collector
-  namespace: banking-app
+  namespace: observability
   labels:
     app: opentelemetry
     component: otel-collector
@@ -196,7 +196,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: otel-collector
-  namespace: banking-app
+  namespace: observability
 spec:
   selector:
     component: otel-collector

--- a/kubernetes/observability/prometheus-config.yaml
+++ b/kubernetes/observability/prometheus-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
-  namespace: banking-app
+  namespace: observability
   labels:
     app: prometheus
     app.kubernetes.io/name: banking-app

--- a/kubernetes/observability/prometheus-config.yaml
+++ b/kubernetes/observability/prometheus-config.yaml
@@ -22,36 +22,36 @@ data:
       # Services were renamed with the banking- prefix and all expose port 80.
       - job_name: 'user-service'
         static_configs:
-          - targets: ['banking-user:80']
+          - targets: ['banking-user.banking-app:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'accounts-service'
         static_configs:
-          - targets: ['banking-accounts:80']
+          - targets: ['banking-accounts.banking-app:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'transactions-service'
         static_configs:
-          - targets: ['banking-transactions:80']
+          - targets: ['banking-transactions.banking-app:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'api-gateway'
         static_configs:
-          - targets: ['banking-gateway:80']
+          - targets: ['banking-gateway.banking-app:80']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
 
       - job_name: 'fraud-service'
         static_configs:
-          - targets: ['banking-fraud:9091']
+          - targets: ['banking-fraud.banking-app:9091']
         metrics_path: '/metrics'
         scrape_interval: 30s
 
       - job_name: 'notification-service'
         static_configs:
-          - targets: ['banking-notification:80']
+          - targets: ['banking-notification.banking-app:80']
         metrics_path: '/metrics'
         scrape_interval: 30s

--- a/kubernetes/observability/prometheus-deployment.yaml
+++ b/kubernetes/observability/prometheus-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus
-  namespace: banking-app
+  namespace: observability
   labels:
     app: prometheus
 spec:
@@ -55,7 +55,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: banking-app
+  namespace: observability
   labels:
     app: prometheus
 spec:


### PR DESCRIPTION
## Summary
- Observability components (Grafana, Prometheus, Loki, Jaeger, OTel collector) now deploy to `observability` namespace instead of co-locating with app workloads in `banking-app`
- App OTEL_EXPORTER_OTLP_ENDPOINT updated to `otel-collector.observability:4317` (cross-namespace DNS)
- Prometheus scrape targets updated to `banking-user.banking-app:80` etc.
- Simulation client OTel endpoint fixed — was pointing directly at Jaeger, now goes through OTel collector like everything else

## Test plan
- [ ] ArgoCD syncs both namespaces cleanly
- [ ] Grafana dashboards still show app metrics (Prometheus cross-namespace scrape)
- [ ] Traces appear in Jaeger (app → otel-collector.observability → jaeger)
- [ ] Gateway API routes for grafana/jaeger may need backend ref namespace update (outside this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)