### PR TITLE
Fix eBPF error panel to show all HTTP errors

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -223,7 +223,7 @@
       "gridPos": {"h": 10, "w": 12, "x": 12, "y": 21},
       "datasource": {"type": "loki", "uid": "loki"},
       "targets": [
-        {"expr": "{exporter=\"OTLP\"} |= \"400\" | json | body_status = \"400\" | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
+        {"expr": "{exporter=\"OTLP\"} | json | body_l7protocol = \"http\" | body_status >= 400 | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
       ],
       "options": {
         "showTime": true,


### PR DESCRIPTION
eBPF panel was hardcoded to `body_status = "400"` but the banking app produces 401s, 409s, and 500s — never literal 400s. Changed to `body_status >= 400` with an `body_l7protocol = "http"` filter to catch all HTTP errors while excluding postgres/grpc noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)