### PR TITLE
Fix JWT userId type mismatch causing 48% error rate

### DIFF
--- a/backend/accounts-service/src/main/java/com/banking/accountsservice/security/JwtTokenUtil.java
+++ b/backend/accounts-service/src/main/java/com/banking/accountsservice/security/JwtTokenUtil.java
@@ -41,7 +41,13 @@ public class JwtTokenUtil {
      * @return user ID
      */
     public Long getUserIdFromToken(String token) {
-        return getClaimFromToken(token, claims -> claims.get("userId", Long.class));
+        return getClaimFromToken(token, claims -> {
+            Object raw = claims.get("userId");
+            if (raw instanceof Number) {
+                return ((Number) raw).longValue();
+            }
+            return Long.parseLong(raw.toString());
+        });
     }
 
     /**

--- a/backend/transactions-service/src/main/java/com/banking/transactionsservice/security/JwtTokenUtil.java
+++ b/backend/transactions-service/src/main/java/com/banking/transactionsservice/security/JwtTokenUtil.java
@@ -41,7 +41,13 @@ public class JwtTokenUtil {
      * @return user ID
      */
     public Long getUserIdFromToken(String token) {
-        return getClaimFromToken(token, claims -> claims.get("userId", Long.class));
+        return getClaimFromToken(token, claims -> {
+            Object raw = claims.get("userId");
+            if (raw instanceof Number) {
+                return ((Number) raw).longValue();
+            }
+            return Long.parseLong(raw.toString());
+        });
     }
 
     /**


### PR DESCRIPTION
User-service (.NET) puts userId as a string in JWT claims. Accounts-service and transactions-service (Java) called `claims.get("userId", Long.class)` which throws `RequiredTypeException` on every authenticated request, returning 401. This caused the 48% error rate visible on the Grafana dashboard.

Fix: parse the raw claim value, handling both numeric and string representations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)