### PR TITLE
Reduce demo error rate from 6% to ~1%

### DIFF
--- a/simulation-client/src/config/index.js
+++ b/simulation-client/src/config/index.js
@@ -63,7 +63,7 @@ const config = {
     // which is what the Banking Health error panel is meant to show.
     errorInjection: {
       enabled: (process.env.ERROR_INJECTION_ENABLED || 'true') === 'true',
-      probability: parseFloat(process.env.ERROR_INJECTION_PROBABILITY) || 0.25
+      probability: parseFloat(process.env.ERROR_INJECTION_PROBABILITY) || 0.05
     }
   },
 

--- a/simulation-client/src/workflows/UserWorkflow.js
+++ b/simulation-client/src/workflows/UserWorkflow.js
@@ -213,8 +213,8 @@ class UserWorkflow {
         // Get balance for each account
         for (const account of accounts) {
           try {
-            const balance = await this.apiClient.getAccountBalance(account.id, user.token);
-            account.balance = balance;
+            const balanceResp = await this.apiClient.getAccountBalance(account.id, user.token);
+            account.balance = typeof balanceResp === 'object' ? balanceResp.balance : balanceResp;
           } catch (error) {
             logger.warn('Failed to get account balance', {
               accountId: account.id,


### PR DESCRIPTION
Error injection probability was 25% — too noisy for a demo. Lowered to 5%.

Also fixed a real bug: `getAccountBalance` returns `{balance: N}` but the workflow stored the whole object as `account.balance`. Then `Math.min(object, 500)` → NaN → null amount → every withdrawal attempt returned 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)