### PR TITLE
Fix gateway 500s on malformed JWT tokens

### DIFF
--- a/backend/api-gateway/src/main/java/com/banking/apigateway/util/JwtUtil.java
+++ b/backend/api-gateway/src/main/java/com/banking/apigateway/util/JwtUtil.java
@@ -31,6 +31,10 @@ public class JwtUtil {
     }
 
     public boolean isInvalid(String token) {
-        return this.isTokenExpired(token);
+        try {
+            return this.isTokenExpired(token);
+        } catch (Exception e) {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Problem

`JwtUtil.isInvalid()` doesn't catch exceptions from `parseClaimsJws()`. When the sim client's `expiredToken` error injection sends a garbage bearer token, `MalformedJwtException` propagates past `AuthenticationFilter` and Spring returns 500 instead of 401. This inflates the error rate by ~1-2% with spurious server errors.

## Solution

Wrap `isTokenExpired()` in a try-catch so any unparseable token is treated as invalid, letting `AuthenticationFilter.onError()` return a proper 401.

## Checklist

- [x] Gateway returns 401 (not 500) for malformed tokens
- [x] No 5xx entries for `/api/accounts` in the Errors by Endpoint table