### PR TITLE
Lower fault injection rate to 0.3%

### DIFF
--- a/backend/api-gateway/src/main/java/com/banking/apigateway/filter/FaultInjectionFilter.java
+++ b/backend/api-gateway/src/main/java/com/banking/apigateway/filter/FaultInjectionFilter.java
@@ -24,7 +24,7 @@ public class FaultInjectionFilter implements GlobalFilter, Ordered {
     };
 
     public FaultInjectionFilter(
-            @Value("${fault.injection.rate:0.008}") double faultRate) {
+            @Value("${fault.injection.rate:0.003}") double faultRate) {
         this.faultRate = faultRate;
     }
 


### PR DESCRIPTION
## Problem

FaultInjectionFilter at 0.8% produced ~29 5xx faults per 30m on 2 req/s gateway throughput, pushing total error rate to 10%.

## Solution

Lower default to 0.3% — ~11 faults per 30m, enough for dashboard visibility without inflating the error rate.

## Checklist

- [x] Still produces 5xx errors every 30m window
- [x] Configurable via `fault.injection.rate` property