### PR TITLE
Fix Errors by Endpoint table query

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -169,7 +169,7 @@
       "datasource": {"type": "prometheus", "uid": "prometheus-app"},
       "targets": [
         {
-          "expr": "100 * sum by (job, method, uri, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / on(job, uri) group_left(method, status) sum by (job, uri) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))",
+          "expr": "100 * sum by (job, method, uri, status) (rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"[45]..\", uri!~\"/actuator.*\"}[5m])) / ignoring(status) group_left sum by (job, method, uri) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))",
           "format": "table", "instant": true, "refId": "A"
         }
       ],


### PR DESCRIPTION
## Problem

Errors by Endpoint table broken — `on(job, uri) group_left(method, status)` fails with "multiple matches" because endpoints like `/api/accounts` are accessed by both GET and POST.

## Solution

Use `ignoring(status) group_left` instead. This matches on all labels except `status`, naturally including `method` in the join key and avoiding the duplicate match.

## Checklist

- [x] Table renders with error % per endpoint
- [x] Verified query against live Prometheus