### PR TITLE
Add cross-links between BYOC dashboards

### DIFF
--- a/kubernetes/observability/dashboards/speedscale-byoc.json
+++ b/kubernetes/observability/dashboards/speedscale-byoc.json
@@ -4,7 +4,10 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "links": [],
+  "links": [
+    {"title": "Live API Traffic →", "icon": "external-link-alt", "type": "link", "url": "/d/speedscale-traffic/speedscale-byoc-live-api-traffic?${__url_time_range}", "targetBlank": false},
+    {"title": "← Overview", "icon": "arrow-left", "type": "link", "url": "/d/banking-app-health/overview?${__url_time_range}&${__all_variables}", "targetBlank": false}
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/kubernetes/observability/dashboards/speedscale-traffic.json
+++ b/kubernetes/observability/dashboards/speedscale-traffic.json
@@ -5,7 +5,9 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "links": [],
+  "links": [
+    {"title": "← BYOC Infrastructure", "icon": "arrow-left", "type": "link", "url": "/d/speedscale-byoc/speedscale-byoc?${__url_time_range}", "targetBlank": false}
+  ],
   "liveNow": false,
   "panels": [
     {


### PR DESCRIPTION
Traffic dashboard was orphaned — no navigation to or from it. Added links between BYOC infra ↔ traffic and BYOC infra → Overview.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>