### PR TITLE
Remove stale sidecar injection annotations

### DIFF
--- a/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: banking-accounts
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"
     capture.speedscale.com/java-agent: "true"

--- a/kubernetes/overlays/speedscale/ai-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/ai-service-annotations.yaml
@@ -4,5 +4,4 @@ metadata:
   name: banking-ai
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
+++ b/kubernetes/overlays/speedscale/api-gateway-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: banking-gateway
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"
     capture.speedscale.com/java-agent: "true"

--- a/kubernetes/overlays/speedscale/fraud-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/fraud-service-annotations.yaml
@@ -4,5 +4,4 @@ metadata:
   name: banking-fraud
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/frontend-annotations.yaml
+++ b/kubernetes/overlays/speedscale/frontend-annotations.yaml
@@ -4,5 +4,4 @@ metadata:
   name: banking-frontend
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/kafka-annotations.yaml
+++ b/kubernetes/overlays/speedscale/kafka-annotations.yaml
@@ -1,7 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: banking-kafka
-  namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/kustomization.yaml
+++ b/kubernetes/overlays/speedscale/kustomization.yaml
@@ -24,7 +24,5 @@ patches:
 - path: ai-service-annotations.yaml
 - path: api-gateway-annotations.yaml
 - path: frontend-annotations.yaml
-- path: simulation-client-annotations.yaml
 - path: fraud-service-annotations.yaml
 - path: notification-service-annotations.yaml
-- path: kafka-annotations.yaml

--- a/kubernetes/overlays/speedscale/notification-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/notification-service-annotations.yaml
@@ -4,5 +4,4 @@ metadata:
   name: banking-notification
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"

--- a/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
+++ b/kubernetes/overlays/speedscale/simulation-client-annotations.yaml
@@ -1,7 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: banking-sim
-  namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "false"

--- a/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
@@ -4,6 +4,5 @@ metadata:
   name: banking-transactions
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"
     capture.speedscale.com/java-agent: "true"

--- a/kubernetes/overlays/speedscale/user-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/user-service-annotations.yaml
@@ -4,5 +4,4 @@ metadata:
   name: banking-user
   namespace: banking-app
   annotations:
-    sidecar.speedscale.com/inject: "false"
     capture.speedscale.com/enabled: "true"


### PR DESCRIPTION
## Summary
- Remove `sidecar.speedscale.com/inject: false` from all 10 annotation files — eBPF mode doesn't use the sidecar
- Delete kafka and simulation-client annotation files (had no other annotations)
- Keep all `capture.speedscale.com/*` annotations (active eBPF config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)