### PR TITLE
Enable AI chat and statement export in sim client

### DIFF
--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -51,8 +51,8 @@ data:
   MAX_TRANSFER: "250.00"
 
   # Feature toggles — disable endpoints that lack backend support
-  AI_CHAT_ENABLED: "false"
-  EXPORT_STATEMENT_ENABLED: "false"
+  AI_CHAT_ENABLED: "true"
+  EXPORT_STATEMENT_ENABLED: "true"
 
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "simulation-client"


### PR DESCRIPTION
## Summary
- Flip AI_CHAT_ENABLED and EXPORT_STATEMENT_ENABLED from false to true
- banking-ai was getting zero real traffic (only health probes), invisible in Speedscale
- Export statement path generates traffic to the S3 integration endpoint

## Test plan
- [ ] banking-ai appears in Speedscale cloud with real traffic
- [ ] Sim client logs show AI assistant requests
- [ ] Export statement calls appear (will 503 if S3 not configured — that's fine for error diversity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)