### PR TITLE
demo: in-cluster Speedscale responder mocks for all third-party calls

### DIFF
--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -21,9 +21,13 @@ data:
   NOTIFICATION_SERVICE_URL: "http://banking-notification:80"
   KAFKA_BROKERS: "banking-kafka:9092"
 
-  # Third-party API overrides (reachable defaults for demo capture)
-  SLACK_WEBHOOK_URL: "https://httpbin.org/anything/slack/webhook"
-  MOODYS_API_URL: "https://httpbin.org/anything/moodys/ratings?identifier=test"
+  # Third-party endpoints — real hosts; Speedscale responder mocks intercept them.
+  # SLACK_WEBHOOK_URL here is a dead, non-secret fallback (no token path); the
+  # notification service gets the live hooks.slack.com webhook URL from the
+  # banking-thirdparty-keys secret. The responder /etc/hosts redirect is driven by
+  # the recorded snapshot's hosts, not by this value.
+  SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/SET-VIA-SECRET"
+  MOODYS_API_URL: "https://api.ratings.moodys.com/research/v1/ratings?identifier=test"
 
   # Observability (language-agnostic OTel)
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4317"

--- a/kubernetes/overlays/speedscale/responders/README.md
+++ b/kubernetes/overlays/speedscale/responders/README.md
@@ -1,0 +1,37 @@
+# Speedscale responder mocks
+
+In-cluster Speedscale **responder-only** `TrafficReplay` CRs that serve every
+third-party outbound call for each service from recorded snapshots — fail-closed
+(404 on no-match, no passthrough), so the app exercises its real integration code
+paths with zero external egress.
+
+Coverage (≈20 third-party APIs across 6 services):
+
+| Service | Snapshot | Third-party calls |
+|---|---|---|
+| accounts | `banking-accounts-mocks` | Plaid (create→exchange→balance), OpenExchangeRates, Moody's |
+| transactions | `banking-transactions-mocks` | Stripe PaymentIntents, PayPal, ComplyAdvantage |
+| fraud | `banking-fraud-mocks` | Sift, Stripe Radar, MaxMind minFraud |
+| notification | `banking-notification-mocks` | SendGrid, Twilio, Slack |
+| user | `banking-user-mocks` | Socure, Jumio, HaveIBeenPwned |
+| ai | `banking-ai-mocks` | Anthropic, OpenAI, Gemini, xAI, OpenRouter |
+
+## Prerequisites (per Speedscale tenant)
+
+The `snapshotID`s and `testConfigID` below must exist in the target tenant. Push
+them with `speedctl push snapshot <id>` / `speedctl push test-config banking-mock-noproxy`.
+`banking-mock-noproxy` is a copy of `standard` with `responder.passthroughMode: false`
+(fail-closed). The Speedscale operator must be installed in the cluster.
+
+## Apply
+
+```sh
+kubectl apply -f kubernetes/overlays/speedscale/responders/
+```
+
+The operator provisions a responder pod + redis per service and injects `/etc/hosts`
+into each SUT, redirecting that service's external hosts to its responder. Remove
+with `kubectl delete -f .` to restore normal (real-egress) behavior.
+
+> Note: each `TrafficReplay` pins a `snapshotID`. These IDs are stable across the
+> `elastic` (staging) and `external` (dev) tenants where the snapshots were pushed.

--- a/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
@@ -1,0 +1,15 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: replay-banking-accounts
+  namespace: banking-app
+spec:
+  # accounts-scoped snapshot (Plaid + OXR + Moody), redacted, pushed to elastic tenant
+  snapshotID: 25ef64bf-c07b-4adc-8ae3-33b2d6d5d6cf
+  testConfigID: banking-mock-noproxy
+  # responder-only = fail-closed: 404 on no-match, NO passthrough to real dependency
+  mode: responder-only
+  workloadRef:
+    kind: Deployment
+    name: banking-accounts
+  cleanup: inventory

--- a/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
@@ -1,0 +1,13 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: replay-banking-ai
+  namespace: banking-app
+spec:
+  snapshotID: 7f7256a0-8876-4e3f-aea9-3fd681e0c36a
+  testConfigID: banking-mock-noproxy
+  mode: responder-only
+  workloadRef:
+    kind: Deployment
+    name: banking-ai
+  cleanup: inventory

--- a/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
@@ -1,0 +1,13 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: replay-banking-fraud
+  namespace: banking-app
+spec:
+  snapshotID: c3898583-282b-4b82-9bdb-72b7dd45d15c
+  testConfigID: banking-mock-noproxy
+  mode: responder-only
+  workloadRef:
+    kind: Deployment
+    name: banking-fraud
+  cleanup: inventory

--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -1,0 +1,13 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: replay-banking-notification
+  namespace: banking-app
+spec:
+  snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
+  testConfigID: banking-mock-noproxy
+  mode: responder-only
+  workloadRef:
+    kind: Deployment
+    name: banking-notification
+  cleanup: inventory

--- a/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
@@ -1,0 +1,13 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: replay-banking-transactions
+  namespace: banking-app
+spec:
+  snapshotID: c7bc4b14-40bd-46ae-88fd-f366b36de453
+  testConfigID: banking-mock-noproxy
+  mode: responder-only
+  workloadRef:
+    kind: Deployment
+    name: banking-transactions
+  cleanup: inventory

--- a/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
@@ -1,0 +1,13 @@
+apiVersion: speedscale.com/v1
+kind: TrafficReplay
+metadata:
+  name: replay-banking-user
+  namespace: banking-app
+spec:
+  snapshotID: 68d2bc15-8931-4093-836e-a5ba3a5a5b5a
+  testConfigID: banking-mock-noproxy
+  mode: responder-only
+  workloadRef:
+    kind: Deployment
+    name: banking-user
+  cleanup: inventory


### PR DESCRIPTION
## Problem
The banking demo's ~20 third-party outbound calls (Plaid, Stripe, PayPal, Sift, MaxMind, SendGrid, Twilio, Slack, Socure, Jumio, HIBP, ComplyAdvantage, OpenExchangeRates, Moody's, and 5 LLM providers) hit real/placeholder endpoints, so the demo couldn't run without live keys/egress.

## Solution
Add responder-only `TrafficReplay` CRs for all 6 services under `kubernetes/overlays/speedscale/responders/`. The Speedscale operator provisions a responder per service and redirects each service's external hosts to it, serving every third-party call from a recorded snapshot — **fail-closed** (404 on no-match, no passthrough, zero external egress). Also point the `app-config` third-party URLs at real hosts (was `httpbin.org`) so the `/etc/hosts` redirect intercepts them.

Verified end-to-end on minikube: all 6 services, every third-party call returns a recorded 2xx, 0 no-match. Snapshots (`banking-*-mocks`) and `testConfigID: banking-mock-noproxy` are pushed to the `elastic` (staging) and `external` (dev) tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)