### PR TITLE
demo: add dummy banking-thirdparty-keys secret (fixes CreateContainerConfigError on decoy)

### DIFF
--- a/kubernetes/base/configmaps/app-secrets.yaml
+++ b/kubernetes/base/configmaps/app-secrets.yaml
@@ -35,3 +35,44 @@ data:
   user-service-password: dXNlcl9zZXJ2aWNlX3Bhc3M=  # base64 encoded "user_service_pass"
   accounts-service-password: YWNjb3VudHNfc2VydmljZV9wYXNz  # base64 encoded "accounts_service_pass"
   transactions-service-password: dHJhbnNhY3Rpb25zX3NlcnZpY2VfcGFzcw==  # base64 encoded "transactions_service_pass"
+---
+# Third-party API credentials. Real calls are served by Speedscale responder mocks,
+# so these are non-functional DUMMY values committed for GitOps reproducibility —
+# every service that integrates a third party only needs this secret to EXIST to
+# start; bad values fail closed (401/warn-and-continue) and never block startup.
+# Override with real values out-of-band only if a cluster must make live calls.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: banking-thirdparty-keys
+  namespace: banking-app
+  labels:
+    app.kubernetes.io/name: banking-app
+    app.kubernetes.io/component: secrets
+type: Opaque
+stringData:
+  AI_API_KEY: "dummy-disabled"
+  AWS_ACCESS_KEY_ID: "dummy-disabled"
+  AWS_SECRET_ACCESS_KEY: "dummysecretdummysecretdummysecret000000"
+  EXCHANGE_RATES_APP_ID: "demo_app_id"
+  GEMINI_API_KEY: "dummy-disabled"
+  HIBP_API_KEY: "dummy-disabled"
+  JUMIO_API_TOKEN: "dummy-disabled"
+  MAXMIND_ACCOUNT_ID: "000000"
+  MAXMIND_LICENSE_KEY: "dummy-disabled"
+  MOODYS_API_KEY: "dummy-disabled"
+  OPENAI_API_KEY: "dummy-disabled"
+  OPENROUTER_API_KEY: "dummy-disabled"
+  PAYMENT_COMPLY_API_KEY: "dummy-disabled"
+  PAYMENT_PAYPAL_ACCESS_TOKEN: "dummy-disabled"
+  PAYMENT_STRIPE_API_KEY: "sk_test_dummy_disabled"
+  PLAID_CLIENT_ID: "dummy-disabled"
+  PLAID_SECRET: "dummy-disabled"
+  SENDGRID_API_KEY: "SG.dummy-disabled.dummy-disabled-dummy-disabled-dummy-disabled0"
+  SIFT_API_KEY: "dummy-disabled"
+  SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/SET-VIA-SECRET"
+  SOCURE_API_KEY: "dummy-disabled"
+  STRIPE_API_KEY: "sk_test_dummy_disabled"
+  TWILIO_ACCOUNT_SID: "ACdummydummydummydummydummydummy00"
+  TWILIO_AUTH_TOKEN: "dummytwilioauthtoken00000000000000"
+  XAI_API_KEY: "dummy-disabled"


### PR DESCRIPTION
## Problem
`banking-thirdparty-keys` (25 third-party API keys) is referenced by every service that calls a third party, but it was a manually-managed secret **not in git**. On any cluster where it wasn't hand-created (both `do-nyc1-dev-decoy` and `do-nyc1-staging-decoy` right now), ArgoCD never creates it, so ai/fraud/notification/transactions/user pods fail with `CreateContainerConfigError: secret "banking-thirdparty-keys" not found`. (Existing replicas kept serving, so nothing was fully down — but new rollouts can't proceed.)

## Solution
Commit the secret with non-functional **dummy** values (same pattern as the existing demo secrets in this file, e.g. postgres `password`). Services only need the secret to *exist* to start; real third-party calls are served by Speedscale responder mocks (or fail closed with a logged warning). Override with real values out-of-band only if a cluster must make live calls.

Validated: `kubectl kustomize kubernetes/base` renders the secret and `kubectl apply --dry-run=client` accepts all 4 secrets. Once merged, ArgoCD will create it on the decoy clusters and the stuck pods will start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)