### PR TITLE
demo: add frontend BFF routes for transaction create/deposit/withdraw/transfer

### DIFF
--- a/frontend/src/app/api/transactions/create/route.ts
+++ b/frontend/src/app/api/transactions/create/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Force Node.js runtime for OpenTelemetry compatibility
+export const runtime = 'nodejs';
+
+const API_GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:8080';
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const body = await request.json();
+
+    const response = await fetch(`${API_GATEWAY_URL}/api/transactions/create`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader && { 'Authorization': authHeader }),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('Create transaction proxy error:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/transactions/deposit/route.ts
+++ b/frontend/src/app/api/transactions/deposit/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Force Node.js runtime for OpenTelemetry compatibility
+export const runtime = 'nodejs';
+
+const API_GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:8080';
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const body = await request.json();
+
+    const response = await fetch(`${API_GATEWAY_URL}/api/transactions/deposit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader && { 'Authorization': authHeader }),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('Deposit transaction proxy error:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/transactions/transfer/route.ts
+++ b/frontend/src/app/api/transactions/transfer/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Force Node.js runtime for OpenTelemetry compatibility
+export const runtime = 'nodejs';
+
+const API_GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:8080';
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const body = await request.json();
+
+    const response = await fetch(`${API_GATEWAY_URL}/api/transactions/transfer`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader && { 'Authorization': authHeader }),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('Transfer transaction proxy error:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/transactions/withdraw/route.ts
+++ b/frontend/src/app/api/transactions/withdraw/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Force Node.js runtime for OpenTelemetry compatibility
+export const runtime = 'nodejs';
+
+const API_GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:8080';
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const body = await request.json();
+
+    const response = await fetch(`${API_GATEWAY_URL}/api/transactions/withdraw`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader && { 'Authorization': authHeader }),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('Withdraw transaction proxy error:', error);
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
The simulation client POSTs `/api/transactions/{create,deposit,withdraw,transfer}` to the Next.js frontend, but only the bare `/api/transactions` route had a POST handler. Those four paths fell through to the dynamic `/api/transactions/[id]` route (GET-only), so Next.js returned **405** for every POST — the dominant error in the demo and the head of a cascade (no transactions → no fraud checks → no third-party calls → empty dashboard panels).

Adds four literal route segments, each a POST handler mirroring the existing `/api/transactions` POST and proxying to `${API_GATEWAY_URL}/api/transactions/<ep>`. Next.js matches literal segments before `[id]`, so these now receive the POSTs. Backend `transactions-service` already implements all four (`@PostMapping` create/deposit/withdraw/transfer). Verified with `next build` — all four now register as routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)