### PR TITLE
demo: switch decoy overlay to responder-only third-party mocks

### DIFF
--- a/kubernetes/overlays/speedscale/kustomization.yaml
+++ b/kubernetes/overlays/speedscale/kustomization.yaml
@@ -5,12 +5,15 @@ resources:
 - ../../base
 - ../../observability
 - speedscale-metrics-services.yaml
-- banking-thirdparty-keys-sealed.yaml
-
-# accounts-service: locally-built image with the real Plaid create→exchange→balance flow
-images:
-- name: ghcr.io/speedscale/microsvc/accounts-service
-  newTag: demo-plaid
+# In-cluster Speedscale responder mocks for every third-party call (responder-only,
+# fail-closed). The app exercises its real integration paths against recorded
+# snapshots with zero external egress; dummy keys from the base secret are fine.
+- responders/replay-banking-accounts.yaml
+- responders/replay-banking-transactions.yaml
+- responders/replay-banking-fraud.yaml
+- responders/replay-banking-notification.yaml
+- responders/replay-banking-user.yaml
+- responders/replay-banking-ai.yaml
 
 patches:
 # Add Istio injection and Speedscale labels to the existing banking-app namespace
@@ -30,10 +33,13 @@ patches:
 - path: frontend-annotations.yaml
 - path: fraud-service-annotations.yaml
 - path: notification-service-annotations.yaml
-# Real third-party API keys (sourced from banking-thirdparty-keys SealedSecret)
+# Wire third-party API keys into each service (sourced from the base
+# banking-thirdparty-keys secret — dummy values; calls are responder-mocked)
 - path: accounts-service-thirdparty-env.yaml
 - path: transactions-service-thirdparty-env.yaml
 - path: fraud-service-thirdparty-env.yaml
 - path: notification-service-thirdparty-env.yaml
 - path: user-service-thirdparty-env.yaml
 - path: ai-service-thirdparty-env.yaml
+# Disable S3 statement export (not responder-mocked) to keep egress at zero
+- path: simulation-client-export-off.yaml

--- a/kubernetes/overlays/speedscale/simulation-client-export-off.yaml
+++ b/kubernetes/overlays/speedscale/simulation-client-export-off.yaml
@@ -1,0 +1,9 @@
+# Statement export hits real S3 (not a host the responders mock), so under the
+# responder-only, zero-egress demo it would 500 on dummy AWS creds. Disable it.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: banking-sim-config
+  namespace: banking-app
+data:
+  EXPORT_STATEMENT_ENABLED: "false"


### PR DESCRIPTION
Switches the decoy demo (`do-nyc1-staging-decoy`, `do-nyc1-dev-decoy`) from real third-party capture to **in-cluster Speedscale responders**, so the app exercises its real integration paths against recorded snapshots with **zero external egress**.

- **Wire the six responder `TrafficReplay` CRs** (`responders/replay-banking-*.yaml`) into `resources` so ArgoCD applies them — a bare `kubectl apply` would be pruned by selfHeal.
- **Drop the `accounts-service:demo-plaid` image override.** That tag isn't in ghcr → `ImagePullBackOff` → accounts-service down. Responder-mock doesn't need the bespoke Plaid image; the released tag (`v1.4.47`) resolves and runs.
- **Remove the `banking-thirdparty-keys` SealedSecret from the overlay.** The base ships a same-named dummy Secret; the two fought over ownership and kept the app Degraded. Responder-mock needs no real keys, so dummy values are fine and the third-party env wiring still resolves against them.
- **Disable the sim's S3 statement export.** S3 isn't a host the responders mock, so it would 500 on dummy AWS creds and break zero-egress.

Validated with `kustomize build`: renders 6 `TrafficReplay` CRs, no `demo-plaid`, no `SealedSecret`, `EXPORT_STATEMENT_ENABLED: "false"`, accounts image `:v1.4.47`. Pairs with #161 (BFF 405 fix); both feed the framework validation (sim successRate + Grafana error rate) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)