### PR TITLE
Fix sim per-account transaction view to use the real endpoint

### DIFF
--- a/simulation-client/src/client/ApiClient.js
+++ b/simulation-client/src/client/ApiClient.js
@@ -152,8 +152,12 @@ class ApiClient {
   }
 
   async getAccountTransactions(accountId, token) {
+    // Per-account history is served by transactions-service at GET /api/transactions?accountId=.
+    // There is no /api/accounts/{id}/transactions route, so the old path 404'd -> stateless
+    // Spring Security re-dispatches to /error unauthenticated -> 401.
     return this.retryRequest(async () => {
-      const response = await this.client.get(`/api/accounts/${accountId}/transactions`, {
+      const response = await this.client.get('/api/transactions', {
+        params: { accountId },
         headers: { Authorization: `Bearer ${token}` }
       });
       return response.data;


### PR DESCRIPTION
## Problem

The simulation client fetches per-account transaction history via `GET /api/accounts/{id}/transactions` (`ApiClient.getAccountTransactions`, called from `UserWorkflow.getAccountsAndBalances`). That route **does not exist** on accounts-service — `AccountController` only maps `/`, `/{id}`, `/{id}/balance`, and `/{id}/export-statement`.

Because accounts-service runs stateless Spring Security with `.anyRequest().authenticated()`, the missing route 404s, re-dispatches to `/error` without a security context, and the `JwtAuthenticationEntryPoint` returns **401**. This produced a steady stream of 401s (~40 per 3‑min window on the decoy clusters) and was the largest remaining error class on the "Banking Application — Errors" dashboard after the responder-mock and 405 fixes.

Note: the account id was already the user's own (picked from `getAccounts`), so this was never an ownership/cross-user problem — the URL itself was wrong.

## Solution

Point `getAccountTransactions` at the endpoint that actually serves per-account history: transactions-service `GET /api/transactions?accountId=` (user-scoped `getUserTransactionsByAccount`), which returns 200.

## Verification

Reproduced locally via `docker-compose` (gateway + accounts + transactions + user-service + postgres/redis). With a freshly registered user querying their **own** account (id 1):

- `GET /api/accounts/1/transactions` → **HTTP 401** (old path)
- `GET /api/transactions?accountId=1` → **HTTP 200** `[]` (new path)

The sim's per-account-transactions 401s will drop to ~0 once this deploys.