### PR TITLE
fix: make docker-compose stack come up clean from a fresh build

### DIFF
--- a/backend/accounts-service/Dockerfile
+++ b/backend/accounts-service/Dockerfile
@@ -55,4 +55,4 @@ ENTRYPOINT ["java", \
     "-Dspring.main.banner-mode=off", \
     "-Dlogging.level.org.springframework.boot.autoconfigure=WARN", \
     "-Dlogging.level.io.opentelemetry=WARN", \
-    "org.springframework.boot.loader.JarLauncher"]
+    "org.springframework.boot.loader.launch.JarLauncher"]

--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -55,4 +55,4 @@ ENTRYPOINT ["java", \
     "-Dspring.main.banner-mode=off", \
     "-Dlogging.level.org.springframework.boot.autoconfigure=WARN", \
     "-Dlogging.level.io.opentelemetry=WARN", \
-    "org.springframework.boot.loader.JarLauncher"]
+    "org.springframework.boot.loader.launch.JarLauncher"]

--- a/backend/transactions-service/Dockerfile
+++ b/backend/transactions-service/Dockerfile
@@ -55,4 +55,4 @@ ENTRYPOINT ["java", \
     "-Dspring.main.banner-mode=off", \
     "-Dlogging.level.org.springframework.boot.autoconfigure=WARN", \
     "-Dlogging.level.io.opentelemetry=WARN", \
-    "org.springframework.boot.loader.JarLauncher"]
+    "org.springframework.boot.loader.launch.JarLauncher"]

--- a/database/init/02-user-service-schema.sql
+++ b/database/init/02-user-service-schema.sql
@@ -1,0 +1,52 @@
+-- User Service schema bootstrap for docker-compose
+--
+-- The .NET user-service (backend/user-service) does NOT run migrations itself --
+-- it queries an existing user_service.users table. In Kubernetes/CI the table is
+-- created by the external Flyway migrations under
+-- database/migrations/user-service/, but docker-compose has no Flyway step, so a
+-- fresh stack would fail register/login with:
+--   relation "user_service.users" does not exist
+--
+-- This script runs in the postgres init phase (after 01-create-schemas.sql, which
+-- creates the user_service schema and the user_service_user role). It mirrors
+-- database/migrations/user-service/V1__Create_users_table.sql. Keep the two in
+-- sync. The heavier V2 simulation seed is intentionally NOT applied here: it
+-- depends on accounts_service.accounts / transactions_service.transactions, which
+-- are created later by the Java services' own Flyway and do not exist at init time.
+
+SET search_path TO user_service;
+
+-- Create users table
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    roles VARCHAR(100) DEFAULT 'USER',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+-- Create updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_users_updated_at ON users;
+CREATE TRIGGER update_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- The table is created by the postgres superuser, so grant the runtime role
+-- explicit access (don't rely solely on default privileges).
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA user_service TO user_service_user;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA user_service TO user_service_user;


### PR DESCRIPTION
## Problem

A fresh `docker compose up --build` did not yield a working stack. Two issues:

### 1. Spring Boot launcher class mismatch
The Java services (`accounts-service`, `transactions-service`, `api-gateway`) build on `spring-boot-starter-parent` **3.2.12**, where the layered-jar launcher moved from `org.springframework.boot.loader.JarLauncher` to `org.springframework.boot.loader.launch.JarLauncher`. All three Dockerfiles still pointed their `ENTRYPOINT` at the old class, so with the layered build (`java -Djarmode=layertools ... extract`) containers crashed on start with:

```
ClassNotFoundException: org.springframework.boot.loader.JarLauncher
```

This only affected **local compose**. The k8s deployments override the container `command`/`args` with the correct `launch.JarLauncher` (see `kubernetes/base/deployments/*-deployment.yaml`), so CI-built images and k8s run fine — the committed Dockerfile `ENTRYPOINT` was simply never exercised there.

**Fix:** update the `ENTRYPOINT` in the three Dockerfiles to `org.springframework.boot.loader.launch.JarLauncher`.

### 2. user-service (.NET) had no DB schema in compose
The .NET `user-service` queries an existing `user_service.users` table but never runs migrations itself. In k8s the table is created by the external Flyway migrations under `database/migrations/user-service/`, but **nothing applies those in docker-compose** (only `database/init/01-create-schemas.sql` is mounted, which creates schemas/roles, no tables). Result: register/login failed with:

```
relation "user_service.users" does not exist
```

**Fix:** add `database/init/02-user-service-schema.sql` (mirrors `V1__Create_users_table.sql`) to the already-mounted postgres init dir. It runs after `01-create-schemas.sql`, creates the `users` table, and grants access to `user_service_user`. The heavier `V2` simulation seed is intentionally **not** applied here — it depends on `accounts_service.accounts` / `transactions_service.transactions`, which the Java services create later via their own Flyway and don't exist at postgres-init time.

## Verification

Fresh stack (isolated project + volume, remapped host ports): `postgres`, `redis`, `user-service`, `accounts-service`, `transactions-service`, `api-gateway`.

- All three Java services started cleanly (`Started …Application in …s`, no `ClassNotFoundException`)
- `POST /api/users/register` → user created
- `POST /api/users/login` → JWT returned
- `POST /api/accounts` → 201, account created
- `GET /api/transactions` → 200 `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)