### PR TITLE
demo: fix blank observability panels (promtail log shipping + error-only panels)

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -204,11 +204,11 @@
     {
       "type": "timeseries",
       "title": "Third-party API Health (fraud-service)",
-      "description": "Outbound calls from fraud-service to Stripe, Sift, and MaxMind. Non-2xx responses indicate provider issues or bad credentials.",
+      "description": "Outbound call rate from fraud-service to Stripe, Sift, and MaxMind, broken out by response status. Healthy traffic shows as 2xx/201 series; any non-2xx series indicates provider issues or bad credentials.",
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "sum by (provider, status) (rate(fraud_external_requests_total{status!~\"2..\"}[1m]))", "legendFormat": "{{provider}} {{status}}", "refId": "A"}
+        {"expr": "sum by (provider, status) (rate(fraud_external_requests_total[1m]))", "legendFormat": "{{provider}} {{status}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -293,12 +293,12 @@
     },
     {
       "type": "logs",
-      "title": "eBPF Traffic — Error Requests",
-      "description": "Speedscale eBPF-captured requests returning errors. Full payload inspection requires Speedscale / proxymock.",
+      "title": "eBPF Traffic — HTTP Requests",
+      "description": "Speedscale eBPF-captured HTTP requests across services (all statuses; 4xx/5xx stand out in the status column). Full payload inspection requires Speedscale / proxymock.",
       "gridPos": {"h": 10, "w": 12, "x": 0, "y": 39},
       "datasource": {"type": "loki", "uid": "loki"},
       "targets": [
-        {"expr": "{exporter=\"OTLP\"} | json | body_l7protocol = \"http\" | body_status >= 400 | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
+        {"expr": "{exporter=\"OTLP\"} | json | body_l7protocol = \"http\" | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
       ],
       "options": {
         "showTime": true,

--- a/kubernetes/observability/promtail.yaml
+++ b/kubernetes/observability/promtail.yaml
@@ -43,6 +43,11 @@ data:
               - __meta_kubernetes_container_name
             target_label: __path__
             separator: /
+            # Without an explicit regex the default (.*) captures the whole
+            # "uid/container" as $1, leaving $2 empty and yielding a malformed
+            # "/var/log/pods/*<uid>/<container>//*.log" glob that matches no
+            # files (promtail ships nothing). Split into $1=uid, $2=container.
+            regex: (.+)/(.+)
             replacement: /var/log/pods/*$1/$2/*.log
         pipeline_stages:
           - cri: {}


### PR DESCRIPTION
Three panels on the **Banking Application — Errors** dashboard showed "No Data". Root causes diagnosed live on staging-decoy:

**Application Logs — Errors** (real bug): promtail is running but ships **nothing** — its `__path__` relabel joins `pod_uid`/`container_name` with `/` but has no `regex`, so the default `(.*)` captures the whole `uid/container` as `$1` and leaves `$2` empty, producing a malformed `/var/log/pods/*<uid>/<container>//*.log` glob that matches no files (`positions.yaml` was `{}`). Added `regex: (.+)/(.+)` → `$1`=uid, `$2`=container → real CRI log paths. Loki then gets `namespace/pod/app/container`-labelled streams and the panel populates.

**Third-party API Health (fraud-service)**: query filtered `status!~"2.."` (errors only). Since the responder mocks return 2xx for every third-party call, there was nothing to plot. Now shows all statuses — healthy 2xx traffic is visible, non-2xx still stands out.

**eBPF Traffic — Error Requests**: filtered `body_status >= 400`, but eBPF captures the (now all-2xx) egress + DB/Kafka, so no ≥400 HTTP records existed. Broadened to all captured HTTP requests and retitled **eBPF Traffic — HTTP Requests**.

Validated with `kustomize build` (renders clean; all three edits present). Deploys via the same `../../observability` ArgoCD path as the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)