### PR TITLE
demo: statement export returns 2xx with zero egress (fix 100%-error endpoint)

### DIFF
--- a/backend/accounts-service/src/main/java/com/banking/accountsservice/controller/AccountController.java
+++ b/backend/accounts-service/src/main/java/com/banking/accountsservice/controller/AccountController.java
@@ -177,26 +177,29 @@ public class AccountController {
     }
     
     @PostMapping("/{accountId}/export-statement")
-    public ResponseEntity<Map<String, String>> exportStatement(
+    public ResponseEntity<Map<String, Object>> exportStatement(
             @PathVariable Long accountId) {
         Span span = tracer.spanBuilder("export-statement").startSpan();
         try {
-            if (!statementExportService.isConfigured()) {
-                Map<String, String> body = new HashMap<>();
-                body.put("status", "unavailable");
-                body.put("reason", "S3 not configured");
-                return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
-            }
-
             Long userId = getUserIdFromAuthentication();
-            logger.info("Exporting statement for account {} user {}", accountId, userId);
-
-            String key = statementExportService.exportStatement(accountId, userId);
             span.setAttribute("user.id", userId);
             span.setAttribute("account.id", accountId);
+
+            if (!statementExportService.isConfigured()) {
+                // No object store wired in this environment: generate the
+                // statement and return it inline (zero external egress) rather
+                // than failing the request.
+                Map<String, Object> body = new HashMap<>();
+                body.put("status", "generated");
+                body.put("statement", statementExportService.generateStatement(accountId, userId));
+                return ResponseEntity.ok(body);
+            }
+
+            logger.info("Exporting statement for account {} user {}", accountId, userId);
+            String key = statementExportService.exportStatement(accountId, userId);
             span.setAttribute("s3.key", key);
 
-            Map<String, String> body = new HashMap<>();
+            Map<String, Object> body = new HashMap<>();
             body.put("status", "exported");
             body.put("key", key);
             return ResponseEntity.ok(body);

--- a/backend/accounts-service/src/main/java/com/banking/accountsservice/service/StatementExportService.java
+++ b/backend/accounts-service/src/main/java/com/banking/accountsservice/service/StatementExportService.java
@@ -66,12 +66,13 @@ public class StatementExportService {
         return configured;
     }
 
-    public String exportStatement(Long accountId, Long userId) {
+    /**
+     * Builds the statement document for an account. Does not touch S3, so it is
+     * safe (and egress-free) to call even when no object store is configured.
+     */
+    public Map<String, Object> generateStatement(Long accountId, Long userId) {
         Account account = accountRepository.findByIdAndUserId(accountId, userId)
                 .orElseThrow(() -> new RuntimeException("Account not found or access denied"));
-
-        String timestamp = Instant.now().toString().replace(":", "-");
-        String key = "statements/account-" + accountId + "/" + timestamp + ".json";
 
         Map<String, Object> statement = new LinkedHashMap<>();
         statement.put("accountId", account.getId());
@@ -80,6 +81,14 @@ public class StatementExportService {
         statement.put("balance", account.getBalance());
         statement.put("exportedAt", LocalDateTime.now().toString());
         statement.put("userId", userId);
+        return statement;
+    }
+
+    public String exportStatement(Long accountId, Long userId) {
+        Map<String, Object> statement = generateStatement(accountId, userId);
+
+        String timestamp = Instant.now().toString().replace(":", "-");
+        String key = "statements/account-" + accountId + "/" + timestamp + ".json";
 
         try {
             byte[] payload = objectMapper.writeValueAsBytes(statement);

--- a/kubernetes/overlays/speedscale/accounts-service-thirdparty-env.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-thirdparty-env.yaml
@@ -30,15 +30,10 @@ spec:
             secretKeyRef:
               name: banking-thirdparty-keys
               key: MOODYS_API_KEY
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: banking-thirdparty-keys
-              key: AWS_ACCESS_KEY_ID
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: banking-thirdparty-keys
-              key: AWS_SECRET_ACCESS_KEY
-        - name: AWS_S3_BUCKET
-          value: "speedscale-banking-demo-statements"
+        # S3 statement export is intentionally left unconfigured here: there is
+        # no object store in this environment and S3 is not a responder-mocked
+        # host, so a real PutObject would egress to AWS and fail on dummy creds.
+        # With AWS_S3_BUCKET unset, StatementExportService.isConfigured() is
+        # false and the controller returns the statement inline (2xx, zero
+        # egress) instead of 500. Re-add the bucket + working creds (or an
+        # in-cluster/MinIO endpoint) to exercise the real upload path.


### PR DESCRIPTION
`POST /api/accounts/{id}/export-statement` was the **only endpoint at ~100% error rate** (confirmed via the Errors-by-Endpoint Prometheus query on staging-decoy). `accounts-service` had `AWS_S3_BUCKET` set with dummy creds, so every call made a **real S3 `PutObject` → AWS 403 → 500** — and that egress also broke the zero-egress guarantee of the responder-mock demo. (The unconfigured path returned 503, still 5xx.)

S3 isn't a responder-mocked host, so nothing intercepts it. Rather than mock S3 or stand up an object store, treat export as best-effort:

- **StatementExportService**: split `generateStatement` (builds the document, no network) from the S3 upload.
- **AccountController**: when no object store is configured, return the generated statement **inline (200)** instead of 503; the configured upload path is unchanged.
- **overlay**: drop `AWS_S3_BUCKET` so `isConfigured()` is false → no S3 client, **no egress**, 200 response.

Result: the endpoint returns 2xx, no real AWS egress, and drops out of the 100%-error bucket. Re-add the bucket + working creds (or a MinIO/in-cluster endpoint) to exercise the real upload path later. `mvn compile` BUILD SUCCESS; `kustomize build` renders clean (no `AWS_S3_BUCKET`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)