### PR TITLE
demo: switch promtail to static file discovery (k8s SD finds 0 targets)

### DIFF
--- a/kubernetes/observability/promtail.yaml
+++ b/kubernetes/observability/promtail.yaml
@@ -16,41 +16,32 @@ data:
       - url: http://loki:3100/loki/api/v1/push
 
     scrape_configs:
-      - job_name: kubernetes-pods
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          # Only collect from banking-app namespace
-          - source_labels: [__meta_kubernetes_namespace]
-            regex: banking-app
-            action: keep
-          # Drop simulation-client logs (too noisy)
-          - source_labels: [__meta_kubernetes_pod_label_app]
-            regex: simulation-client
-            action: drop
-          # Standard k8s metadata labels
-          - source_labels: [__meta_kubernetes_namespace]
-            target_label: namespace
-          - source_labels: [__meta_kubernetes_pod_name]
-            target_label: pod
-          - source_labels: [__meta_kubernetes_pod_label_app]
-            target_label: app
-          - source_labels: [__meta_kubernetes_container_name]
-            target_label: container
-          # Use the pod log path
-          - source_labels:
-              - __meta_kubernetes_pod_uid
-              - __meta_kubernetes_container_name
-            target_label: __path__
-            separator: /
-            # Without an explicit regex the default (.*) captures the whole
-            # "uid/container" as $1, leaving $2 empty and yielding a malformed
-            # "/var/log/pods/*<uid>/<container>//*.log" glob that matches no
-            # files (promtail ships nothing). Split into $1=uid, $2=container.
-            regex: (.+)/(.+)
-            replacement: /var/log/pods/*$1/$2/*.log
+      # Kubernetes pod service-discovery returns zero targets on this cluster
+      # (RBAC + config are correct, but promtail 2.9.8's k8s SD silently
+      # discovers nothing here). Tail the CRI pod logs straight off the mounted
+      # /var/log/pods hostPath instead — deterministic and SD-free. promtail
+      # runs as root and the path is mounted, so the files are readable.
+      - job_name: banking-app
+        static_configs:
+          - targets: [localhost]
+            labels:
+              namespace: banking-app
+              __path__: /var/log/pods/banking-app_*/*/*.log
         pipeline_stages:
           - cri: {}
+          # Derive pod/container from the log file path
+          # (/var/log/pods/<ns>_<pod>_<uid>/<container>/<n>.log)
+          - regex:
+              source: filename
+              expression: '/var/log/pods/[^_]+_(?P<pod>.+)_[^_/]+/(?P<container>[^/]+)/[^/]+\.log'
+          - labels:
+              pod:
+              container:
+          # Keep the panel focused on application containers: drop the sim load
+          # generator and the injected init/sidecar containers.
+          - drop:
+              source: container
+              expression: 'simulation-client|speedscale-.*|wait-for-.*|istio-.*'
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Follow-up to #165. The `__path__` relabel fix in #165 was correct, but verifying live on staging-decoy revealed promtail still ships **nothing**: its `kubernetes_sd_configs` (`role: pod`) discovers **zero targets** (`promtail_targets_active_total 0`, `positions.yaml: {}`) even though:
- the ClusterRole/binding are correct (`kubectl auth can-i list pods --as=…:promtail` → yes),
- the config is valid and discovery initializes with no errors,
- promtail runs as **root** and **can read** the log files (verified),
- the files exist and are actively written under the mounted `/var/log/pods`.

Its a promtail 2.9.8 / cluster-specific SD quirk I could not root-cause from RBAC/config/logs. Rather than keep chasing the SD black box, switch to **static file discovery**: tail `/var/log/pods/banking-app_*/*/*.log` directly (SD-free, deterministic). `namespace` is static; `pod`/`container` are derived from the file path; the sim and injected init/sidecar containers are dropped so the **Application Logs — Errors** panel stays focused on app containers.

`kustomize build` renders clean (static_configs present, 0 `kubernetes_sd_configs`). **Needs post-merge verification** that Loki gains `namespace/pod/container` streams and the panel populates — I could not test live (manual `kubectl apply` is correctly blocked as a GitOps bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)