### PR TITLE
demo: make Errors dashboard standard-monitoring only (remove eBPF panel)

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -290,26 +290,6 @@
         "sortOrder": "Descending",
         "dedupStrategy": "none"
       }
-    },
-    {
-      "type": "logs",
-      "title": "eBPF Traffic — HTTP Requests",
-      "description": "Speedscale eBPF-captured HTTP requests across services (all statuses; 4xx/5xx stand out in the status column). Full payload inspection requires Speedscale / proxymock.",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 39},
-      "datasource": {"type": "loki", "uid": "loki"},
-      "targets": [
-        {"expr": "{exporter=\"OTLP\"} | json | body_l7protocol = \"http\" | line_format \"{{.body_service}} {{.body_command}} {{.body_location}} → {{.body_status}} ({{.body_duration}}ms)\"", "refId": "A"}
-      ],
-      "options": {
-        "showTime": true,
-        "showLabels": false,
-        "showCommonLabels": false,
-        "wrapLogMessage": false,
-        "prettifyLogMessage": false,
-        "enableLogDetails": true,
-        "sortOrder": "Descending",
-        "dedupStrategy": "none"
-      }
     }
   ]
 }


### PR DESCRIPTION
Per the intended 2-part demo story: **part 1 = standard monitoring** (this dashboard — Prometheus metrics + Jaeger traces + Loki application logs), which deliberately reflects only what the app instruments (Spring `http_server_requests_seconds_count` = the Java services). **Part 2 = Speedscale eBPF full-fidelity** capture, used to *reproduce* what standard monitoring can't show.

Mixing the eBPF traffic panel onto this dashboard made the error counts read as inconsistent — Prometheus showed ~2 errors, eBPF ~63 (incl. 18 from the uninstrumented Next.js frontend). That contrast *is* the story, but it belongs across the two views, not jammed into one. This removes the eBPF panel from the standard-monitoring dashboard (it can't be Prometheus-sourced anyway); the eBPF view lives in the Speedscale traffic dashboard.

Dashboard now: metrics (Prometheus 0–8) + traces (Jaeger) + app logs (Loki). 12→11 panels, `kustomize build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)