### PR TITLE
demo: stop Loki OOM under log volume; fix Application Logs panel

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -278,7 +278,7 @@
       "gridPos": {"h": 10, "w": 12, "x": 12, "y": 29},
       "datasource": {"type": "loki", "uid": "loki"},
       "targets": [
-        {"expr": "{namespace=\"banking-app\"} |~ \"(?i)(ERROR|WARN|Exception|panic|fatal)\"", "refId": "A"}
+        {"expr": "{namespace=\"banking-app\", container=~\".+\"} |~ \"(?i)(ERROR|WARN|Exception|panic|fatal)\"", "refId": "A"}
       ],
       "options": {
         "showTime": true,

--- a/kubernetes/observability/loki.yaml
+++ b/kubernetes/observability/loki.yaml
@@ -80,9 +80,9 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
-            limits:
               memory: 512Mi
+            limits:
+              memory: 2Gi
       volumes:
         - name: config
           configMap:

--- a/kubernetes/observability/promtail.yaml
+++ b/kubernetes/observability/promtail.yaml
@@ -42,6 +42,15 @@ data:
           - drop:
               source: container
               expression: 'simulation-client|speedscale-.*|wait-for-.*|istio-.*'
+          # Drop high-volume DEBUG/TRACE lines (the Spring Cloud Gateway alone
+          # emits multi-MB of reactor DEBUG noise) — it OOM-kills the small Loki
+          # and the errors panel only surfaces WARN/ERROR/fatal anyway.
+          - match:
+              selector: '{namespace="banking-app"}'
+              stages:
+                - drop:
+                    expression: '(?i)\s(DEBUG|TRACE)\s'
+                    drop_counter_reason: debug_trace_volume
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
The Application Logs panel was still "No data" after #167 — but not because logs were not shipping. Diagnosed live: **Loki (512Mi) was OOMKilled 14x in a crash loop** ("empty ring" 500 on every push/query). #167 turned on real log shipping and the volume — dominated by the Spring Cloud Gateway's multi-MB reactor **DEBUG** noise — overwhelms a 512Mi Loki.

Three-part fix:
- **promtail**: drop `DEBUG`/`TRACE` lines for `banking-app` (the errors panel only surfaces WARN/ERROR/fatal, so nothing useful is lost; volume drops sharply).
- **loki**: memory request 256Mi→512Mi, limit 512Mi→**2Gi** (headroom + WAL recovery).
- **dashboard**: scope the Application Logs query to `{namespace="banking-app", container=~".+"}` so it excludes the eBPF **OTLP** stream (which also carries `namespace="banking-app"`) — correctness and far less data scanned per refresh.

`kustomize build` clean. After merge + sync I'll confirm Loki stops OOMing and the panel fills with WARN/ERROR lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
