### PR TITLE
demo: exclude Postgres port from eBPF capture (stop nettap OOM loop)

### DIFF
--- a/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/accounts-service-annotations.yaml
@@ -6,3 +6,6 @@ metadata:
   annotations:
     capture.speedscale.com/enabled: "true"
     capture.speedscale.com/java-agent: "true"
+    # Exclude Postgres wire from eBPF capture: nettap joins long-lived HikariCP
+    # connections mid-stream, never syncs, and leaks buffers -> ingest OOMKill loop.
+    capture.speedscale.com/ignore-ports: "5432"

--- a/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/transactions-service-annotations.yaml
@@ -6,3 +6,6 @@ metadata:
   annotations:
     capture.speedscale.com/enabled: "true"
     capture.speedscale.com/java-agent: "true"
+    # Exclude Postgres wire from eBPF capture: nettap joins long-lived HikariCP
+    # connections mid-stream, never syncs, and leaks buffers -> ingest OOMKill loop.
+    capture.speedscale.com/ignore-ports: "5432"

--- a/kubernetes/overlays/speedscale/user-service-annotations.yaml
+++ b/kubernetes/overlays/speedscale/user-service-annotations.yaml
@@ -5,3 +5,6 @@ metadata:
   namespace: banking-app
   annotations:
     capture.speedscale.com/enabled: "true"
+    # Exclude Postgres wire from eBPF capture: nettap joins long-lived Npgsql pool
+    # connections mid-stream, never syncs, and leaks buffers -> ingest OOMKill loop.
+    capture.speedscale.com/ignore-ports: "5432"


### PR DESCRIPTION
## Problem
`speedscale-nettap` ingest containers OOMKill (exit 137) roughly every ~2h on the two nodes that carry the Postgres-backed services (14 and 4 restarts over 47h; the frontend-only node has 0). The pre-crash logs are dominated by `unable to sync postgres streams` / `unknown message type` on `:5432`. Root cause: nettap joins long-lived connection-pool sockets (HikariCP / Npgsql) **mid-stream**, can never sync to a Postgres message boundary, and **retains the buffered per-connection state unbounded** until it hits the 1G limit. Undissectable-stream rate tracks the crash (healthy node 21%, OOM node 77%). Raising the memory limit only delays the OOM — the fix is to stop feeding nettap traffic it can't parse.

## Solution
Add `capture.speedscale.com/ignore-ports: "5432"` to the three Postgres clients — **accounts**, **transactions**, **user**. Postgres wire capture has no demo value; service HTTP/gRPC traffic is unaffected.

## Notes
- The underlying unbounded-retention behavior in nettap is a product defect (tracked separately) — this is the operational fix for the demo.
- Remaining minor leak contributors (`:443` responder-mock TLS that eBPF can't decrypt) can get the same treatment if the OOM recurs after this lands.