### PR TITLE
docker-compose: add missing fraud-service (gRPC dependency)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
     container_name: banking-transactions-service
     depends_on:
       - postgres
+      - fraud-service
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - DB_HOST=postgres
@@ -101,6 +102,8 @@ services:
       - JWT_EXPIRATION=86400000
       # Service URLs
       - ACCOUNTS_SERVICE_URL=http://accounts-service:8080
+      - FRAUD_SERVICE_HOST=fraud-service
+      - FRAUD_SERVICE_PORT=50051
       # OpenTelemetry Configuration
       - OTEL_SERVICE_NAME=transactions-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
@@ -115,6 +118,21 @@ services:
     ports:
       - "8083:8080"
       - "5005:5005"
+    networks:
+      - banking-network
+
+  # Fraud detection (gRPC) — transactions-service calls this for every transaction.
+  # Without it the fraud gRPC call fails and the client fails open (no fraud checks).
+  fraud-service:
+    build:
+      context: ./backend/fraud-service
+      dockerfile: Dockerfile
+    container_name: banking-fraud-service
+    environment:
+      - GRPC_PORT=50051
+      - METRICS_PORT=9091
+    ports:
+      - "50051:50051"
     networks:
       - banking-network
 


### PR DESCRIPTION
## Problem
`transactions-service` calls `fraud-service` over gRPC (`:50051`) on every create/withdraw, but **fraud-service is absent from `docker-compose.yml`**. Locally the gRPC call fails and `FraudServiceClient` **fails open** — no fraud checks run, so over-limit transactions (e.g. the sim's $100M "Simulated overdraw") are silently *approved* instead of *declined*. The local app diverges from the deployed cluster.

## Solution
Add the `fraud-service` container (built from `./backend/fraud-service`, gRPC `:50051`) and wire `transactions-service` to it via `FRAUD_SERVICE_HOST`/`FRAUD_SERVICE_PORT` + `depends_on`.

## Verification
With fraud-service running, a $100M withdrawal is correctly declined: transactions logs `approved=false ... reason=Amount exceeds limit` and returns 400, matching cluster behavior. `docker compose config` validates. (Verified against the same v1.4.53 images the cluster runs.)

## Note (separate, not in this PR)
The .NET `user-service` table isn't auto-migrated by `docker-compose` (the cluster uses the `seed-demo-user` job); local registration fails until that's seeded. Flagging separately to keep this change minimal.