### PR TITLE
postgres: Recreate strategy to fix RWO volume Multi-Attach deadlock

### DIFF
--- a/kubernetes/base/database/postgres-deployment.yaml
+++ b/kubernetes/base/database/postgres-deployment.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/component: database
 spec:
   replicas: 1
+  # The Postgres PVC is RWO block storage (do-block-storage) and can attach to only
+  # one pod at a time. The default RollingUpdate surges a new pod that deadlocks on a
+  # Multi-Attach error against the still-running old pod, so rollouts never complete.
+  # Recreate terminates the old pod (releasing the volume) before starting the new one.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: banking-postgres


### PR DESCRIPTION
## Problem
`banking-postgres` rollouts get stuck on **both** decoy clusters: a new pod sits in `ContainerCreating` with `FailedAttachVolume ... Multi-Attach error for volume ... already used by pod banking-postgres-...`. The PVC is **RWO** block storage (`do-block-storage`, attachable to one pod at a time), but the Deployment uses the default **RollingUpdate**, which surges the new pod before terminating the old one → the volume can never attach → the rollout never completes and ArgoCD shows the app Degraded/Progressing.

## Solution
Add `strategy: { type: Recreate }` to the postgres Deployment so the old pod is terminated (releasing the RWO volume) before the new pod starts. Single-replica demo DB, so the brief restart-window is acceptable. (A StatefulSet would also solve it but is a larger change; Recreate is the minimal fix.)

## Verification
`kubectl kustomize kubernetes/overlays/speedscale` builds clean. Observed the Multi-Attach deadlock on dev-decoy (`banking-postgres-8c5f85d66-*` stuck behind `banking-postgres-577fb96ccd-*`) and staging-decoy; Recreate eliminates the overlap.