### PR TITLE
user-service: seed sim_user_* pool on startup (fix simulator 401s)

### DIFF
--- a/backend/user-service/Program.cs
+++ b/backend/user-service/Program.cs
@@ -70,6 +70,40 @@ using (var scope = app.Services.CreateScope())
         Console.WriteLine("[startup] user_service schema bootstrap did not complete; continuing startup (real Postgres should already be migrated, mocked Postgres answers queries directly).");
 }
 
+// Seed the sim_user_NNN pool the load-simulation client logs into. The simulator assumes
+// these accounts pre-exist and does NOT register them (≈80% of its sessions reuse this
+// pool), so on a fresh or wiped database every simulator login 401s. Flyway migration
+// V2__Seed_simulation_users.sql seeds them for the Java services but never runs against
+// this .NET service (no Flyway) — same gap the table bootstrap above closes. We hash the
+// password with the very BCrypt call the register/login path uses (Models match: roles is
+// a plain VARCHAR, not an array), so the seeded credentials verify. Idempotent via
+// ON CONFLICT and best-effort like the bootstrap above (a mocked Postgres in CI just
+// no-ops). Password/count are overridable to track the simulator's SIM_USER_PASSWORD.
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var simPassword = Environment.GetEnvironmentVariable("SIM_USER_PASSWORD") ?? "SimUser123!";
+    var simCount = int.TryParse(Environment.GetEnvironmentVariable("SIM_USER_COUNT"), out var c) ? c : 1000;
+    var simHash = BCrypt.Net.BCrypt.HashPassword(simPassword);
+    const string seedSql = @"
+        INSERT INTO user_service.users (username, email, password_hash, roles, created_at, updated_at)
+        SELECT 'sim_user_' || LPAD(g::text, 3, '0'),
+               'sim_user_' || LPAD(g::text, 3, '0') || '@simulation.local',
+               {0}, 'USER', NOW(), NOW()
+        FROM generate_series(1, {1}) AS g
+        ON CONFLICT (username) DO NOTHING;";
+    try
+    {
+        var seeded = db.Database.ExecuteSqlRaw(seedSql, simHash, simCount);
+        if (seeded > 0)
+            Console.WriteLine($"[startup] seeded {seeded} sim_user_* accounts for the load simulator.");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"[startup] sim_user_* seed skipped: {ex.Message} (continuing; a healthy Postgres seeds on next startup).");
+    }
+}
+
 app.UseHttpMetrics();
 app.MapControllers();
 app.MapGet("/actuator/health", () => Results.Ok(new { status = "UP" }));


### PR DESCRIPTION
## Problem
The dev-decoy banking-frontend shows a flood of 401s. Root cause: the load-simulation client reuses a pre-existing `sim_user_001..1000` pool for ~80% of its sessions (`EXISTING_USER_PERCENTAGE=80`, `isPreExisting:true`) and **logs in without registering them**. Those rows are created only by Flyway migration `V2__Seed_simulation_users.sql`, which **never runs against the .NET user-service** (it has no Flyway — the same self-migration gap that #174/#175 closed for the table). On a fresh or wiped database the pool doesn't exist, so every simulator login 401s. `new_user_*` sessions work because the sim registers those fresh. Everything is on the same DB — it's missing seed data, not a DB mismatch.

## Solution
Extend the startup bootstrap (the same block that self-creates `user_service.users`) to seed the pool, hashing the password with the **same `BCrypt.Net.BCrypt.HashPassword` call the register/login path uses**, so the seeded credentials verify against `BCrypt.Verify` at login. Idempotent (`ON CONFLICT (username) DO NOTHING`) and best-effort like the table bootstrap (a mocked Postgres in CI just no-ops). `SIM_USER_PASSWORD`/`SIM_USER_COUNT` default to the simulator's own `SimUser123!` / 1000 and are overridable. Self-heals after any future DB wipe.

Builds clean (`dotnet build`, 0 warnings/errors).

Note: `V2__Seed_simulation_users.sql` also hardcodes the **wrong** password (`NewUser123!`) vs the simulator's `SimUser123!`; seeding in-app sidesteps that stale hash entirely.