### PR TITLE
sim: continuous error injection so the demo errors board is always populated

### DIFF
--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -35,6 +35,13 @@ data:
   BURST_DURATION_MS: "30000"      # each burst lasts ~30s
   BURST_JITTER_MS: "60000"        # ±60s randomness on interval
 
+  # Error injection — keep the errors board continuously populated for the demo.
+  # Default is a 5% baseline with 2-min spikes at :10/:40, which leaves /create at
+  # ~0% between spikes (you can't reliably point at the 4xx spike on camera). 0.6
+  # runs an unhappy path on most sessions, reproducing the ~25% /create error board
+  # the demo investigates — continuously, not just for 2 minutes twice an hour.
+  ERROR_INJECTION_PROBABILITY: "0.6"
+
   # User pool configuration
   USER_PREFIX: "sim_user_"
   TOTAL_USERS: "1000"


### PR DESCRIPTION
## Problem
The Part 1 demo beat — point at the 4xx spike on `POST /api/transactions/create` in the errors dashboard — only works for ~2 minutes twice an hour. The sim defaults to a 5% error baseline with scheduled spikes at `:10`/`:40` (2 min, 60%). Between spikes `/create` sits at ~0%, so most of the time the board is empty and you can't reliably record the beat. (Confirmed on staging-decoy: a burst of `/create` 400s at :41–:43, then 0% for the next ~10 min.)

## Solution
Set `ERROR_INJECTION_PROBABILITY=0.6` in the sim configmap so most sessions run a realistic unhappy path (overdraw → fraud 400, bad login 401, missing account 404, service-unavailable 503, invalid amount 400). This reproduces the **~25% `/create` error board the demo already investigates — continuously**, instead of only during the 2-min spikes. Also keeps fresh `$100M` overdraw RRPairs in the capture at all times for the eBPF reproduce beat.

Burst/spike settings are left intact; the rate is tunable via the same env var. Verified the overlay renders the key via `kubectl kustomize`.

## Deploy note
ArgoCD (`microsvc-staging-decoy`, selfHeal) will apply the configmap on merge; the sim pod must be restarted once to pick up the new env (`kubectl rollout restart deploy/banking-sim -n banking-app`).