### PR TITLE
sim: mix locales on /api/chat so AI errors are intermittent

### DIFF
--- a/simulation-client/src/client/ApiClient.js
+++ b/simulation-client/src/client/ApiClient.js
@@ -255,8 +255,18 @@ class ApiClient {
   }
 
   async askAIChat(message, token) {
+    // Mixed locales across sessions: most users are en-US (some get smart "—"/curly
+    // quotes from the model = ok under cp1252), a real but minority slice are
+    // ja-JP/es-MX etc. Drives an intermittent, per-locale error pattern on the AI
+    // chat endpoint — the demo's investigation hook.
+    const LOCALES = [
+      'en-US','en-US','en-US','en-US','en-US','en-US','en-US',  // ~70%
+      'es-MX','es-MX',                                          // ~20%
+      'ja-JP',                                                  // ~10%
+    ];
+    const locale = LOCALES[Math.floor(Math.random() * LOCALES.length)];
     return this.retryRequest(async () => {
-      const response = await this.client.post('/api/ai/chat', { message }, {
+      const response = await this.client.post('/api/ai/chat', { message, locale }, {
         headers: { Authorization: `Bearer ${token}` }
       });
       return response.data;


### PR DESCRIPTION
Without a locale the sim sent no field, every chat defaulted to `en-US`, and 100% of `/api/chat` 500'd against the Japanese-drift responder reply. Mix locales across sessions (~70% `en-US`, ~20% `es-MX`, ~10% `ja-JP`) so `en-US`/`es-MX` (cp1252) trip the encode while `ja-JP` (shift_jis) succeeds — the AI 500 stays the board's headline, but with the per-locale variation the demo investigates ("why is this happening to some users?").