### PR TITLE
ai-service: Asian locales use UTF-8 (intermittent AI errors by locale)

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -44,12 +44,15 @@ PROVIDER_URLS = {
     "openrouter": os.environ.get("OPENROUTER_URL", "https://openrouter.ai/api/v1/chat/completions"),
 }
 
-# Downstream delivery (notifications, statements, legacy core) consumes the assistant
-# reply in the user's locale-specific legacy encoding — not everything is UTF-8 yet.
+# Downstream delivery (notifications, statements, legacy core) consumes the assistant reply in
+# the user's locale-specific encoding. Asian locales were forced to UTF-8 long ago (shift_jis /
+# gb2312 are too narrow for the language) so emoji and rare characters survive. Western locales
+# are still on legacy cp1252 for downstream compatibility — a model reply with an emoji blows it
+# up. Same response payload, the outcome diverges purely by the request's locale.
 LOCALE_CHARSET = {
     "en-US": "cp1252", "en-GB": "cp1252",
     "fr-FR": "cp1252", "de-DE": "cp1252", "es-ES": "cp1252", "es-MX": "cp1252",
-    "ja-JP": "shift_jis", "zh-CN": "gb2312",
+    "ja-JP": "utf-8", "zh-CN": "utf-8", "ko-KR": "utf-8",
 }
 DEFAULT_CHARSET = "cp1252"
 


### PR DESCRIPTION
Decouples the AI demo's intermittency from the response content. `ja-JP`/`zh-CN`/`ko-KR` map to `utf-8` (those locales were forced off single-byte charsets long ago to fit their native characters), so when the LLM returns an emoji in a reply they succeed. `en-US`/`es-MX`/`fr-FR`/`de-DE` stay on legacy `cp1252` for downstream compatibility — emoji blows it up.

Same response payload, fate diverges purely by the request `locale` field. So on the dashboard the locale becomes the clear signal — "all the failing requests are en-US/es-MX, all the succeeding ones are ja-JP" — exactly the investigation hook for the demo.

Validated locally through the real chat() handler: emoji reply + locale=en-US/es-MX/fr-FR → **500**; locale=ja-JP/zh-CN → **200**.