### PR TITLE
ai-service: expose Micrometer-compatible /actuator/prometheus so it shows on the dashboards

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -4,8 +4,9 @@ import os
 import time
 
 import httpx
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Histogram, generate_latest
 from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
@@ -18,6 +19,37 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Match the Spring Boot Micrometer metric name + label set the banking-app dashboards use,
+# so /api/chat shows up in the cross-service "Errors by Endpoint" / "Status Codes by Service"
+# panels alongside the Java services. Histogram (not Counter) so the exposed series is named
+# http_server_requests_seconds_count — without prometheus_client's automatic `_total` suffix.
+_metrics_registry = CollectorRegistry()
+_HTTP_REQUESTS = Histogram(
+    "http_server_requests_seconds",
+    "HTTP server requests (Micrometer-compatible)",
+    ["method", "uri", "status", "outcome"],
+    registry=_metrics_registry,
+)
+
+
+@app.middleware("http")
+async def _record_http_metrics(request: Request, call_next):
+    if request.url.path in ("/metrics", "/actuator/prometheus", "/health"):
+        return await call_next(request)
+    start = time.monotonic()
+    response = await call_next(request)
+    elapsed = time.monotonic() - start
+    status = str(response.status_code)
+    outcome = "SUCCESS" if response.status_code < 400 else "CLIENT_ERROR" if response.status_code < 500 else "SERVER_ERROR"
+    _HTTP_REQUESTS.labels(request.method, request.url.path, status, outcome).observe(elapsed)
+    return response
+
+
+@app.get("/actuator/prometheus")
+@app.get("/metrics")
+def _metrics_endpoint() -> Response:
+    return Response(generate_latest(_metrics_registry), media_type=CONTENT_TYPE_LATEST)
 
 SYSTEM_PROMPT = (
     "You are a helpful banking assistant for Apex Banking. "

--- a/backend/ai-service/requirements.txt
+++ b/backend/ai-service/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.0
 httpx==0.27.0
+prometheus-client==0.21.0

--- a/kubernetes/observability/prometheus-config.yaml
+++ b/kubernetes/observability/prometheus-config.yaml
@@ -55,3 +55,9 @@ data:
           - targets: ['banking-notification.banking-app:80']
         metrics_path: '/metrics'
         scrape_interval: 30s
+
+      - job_name: 'ai-service'
+        static_configs:
+          - targets: ['banking-ai.banking-app:80']
+        metrics_path: '/actuator/prometheus'
+        scrape_interval: 30s


### PR DESCRIPTION
## Problem
The Grafana banking-app dashboards (Errors by Endpoint, Status Codes by Service, Errors per Service) query `http_server_requests_seconds_count` — the Micrometer metric the Java services emit. `ai-service` (FastAPI/Python) had no `/metrics` endpoint, and Prometheus had no scrape job for it. So `/api/chat` was **invisible on every cross-service panel**, including the AI demo's headline error panel.

## Solution
- FastAPI middleware emits the exact metric `http_server_requests_seconds_count` (Histogram, so the `_count` series is named without prometheus_client's automatic `_total` suffix) with the same `{method, uri, status, outcome}` labels Spring Boot uses.
- `/actuator/prometheus` endpoint exposed (also aliased to `/metrics`).
- Prometheus scrape job added (`kubernetes/observability/prometheus-config.yaml`).
- `prometheus-client` added to requirements.

Validated locally — emits exactly:
```
http_server_requests_seconds_count{method="POST",uri="/api/chat",status="200",outcome="SUCCESS"} 3.0
```
which is the series shape the dashboard's `sum by (job,method,uri,status)(rate(...{status=~"[45].."}[5m]))` will pick up.