### PR TITLE
ai-service: record /api/chat 500s on the metrics endpoint (finally{})

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -38,12 +38,16 @@ async def _record_http_metrics(request: Request, call_next):
     if request.url.path in ("/metrics", "/actuator/prometheus", "/health"):
         return await call_next(request)
     start = time.monotonic()
-    response = await call_next(request)
-    elapsed = time.monotonic() - start
-    status = str(response.status_code)
-    outcome = "SUCCESS" if response.status_code < 400 else "CLIENT_ERROR" if response.status_code < 500 else "SERVER_ERROR"
-    _HTTP_REQUESTS.labels(request.method, request.url.path, status, outcome).observe(elapsed)
-    return response
+    status_code = 500  # if call_next raises, FastAPI's default handler turns it into a 500 downstream
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+        return response
+    finally:
+        elapsed = time.monotonic() - start
+        status = str(status_code)
+        outcome = "SUCCESS" if status_code < 400 else "CLIENT_ERROR" if status_code < 500 else "SERVER_ERROR"
+        _HTTP_REQUESTS.labels(request.method, request.url.path, status, outcome).observe(elapsed)
 
 
 @app.get("/actuator/prometheus")


### PR DESCRIPTION
## Problem
#186 added a Prometheus metric for HTTP requests, but the .observe() call ran **after** `await call_next(request)` returned. When the request handler **raises** (UnicodeEncodeError on locale-mismatched LLM replies — the actual demo bug), FastAPI's default exception handler converts the raise into a 500 downstream, but the middleware's metric code never executed. Net effect: `/api/chat` 500s were generated and visible in access logs, but never showed up in `/actuator/prometheus`, so Grafana's "Errors by Endpoint" panel stayed blank for AI even though staging-decoy was 500ing constantly.

## Solution
Move the `.observe()` into `finally{}` with a `status_code = 500` default; on the success return path the status is overwritten with the actual response status before the finally runs. 200/500 split now records correctly. No behavior change on success.