### PR TITLE
ai-service: emit OTel spans so it shows up in Jaeger

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -6,13 +6,32 @@ import time
 import httpx
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Histogram, generate_latest
 from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# OpenTelemetry — feed spans to the cluster otel-collector so ai-service shows
+# up in Jaeger alongside the Java services. The collector address comes from
+# OTEL_EXPORTER_OTLP_ENDPOINT (banking-ai-config ConfigMap, http/protobuf on
+# :4318 — same as the frontend Node service uses).
+_otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.observability:4318")
+_otel_service_name = os.environ.get("OTEL_SERVICE_NAME", "ai-service")
+_tracer_provider = TracerProvider(resource=Resource.create({"service.name": _otel_service_name, "service.namespace": "banking-app"}))
+_tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{_otel_endpoint.rstrip('/')}/v1/traces")))
+trace.set_tracer_provider(_tracer_provider)
+HTTPXClientInstrumentor().instrument()
+
 app = FastAPI(title="AI Service")
+FastAPIInstrumentor.instrument_app(app)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/backend/ai-service/requirements.txt
+++ b/backend/ai-service/requirements.txt
@@ -2,3 +2,8 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.0
 httpx==0.27.0
 prometheus-client==0.21.0
+opentelemetry-api==1.31.0
+opentelemetry-sdk==1.31.0
+opentelemetry-exporter-otlp-proto-http==1.31.0
+opentelemetry-instrumentation-fastapi==0.52b0
+opentelemetry-instrumentation-httpx==0.52b0

--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -180,3 +180,26 @@ data:
   # Next.js configuration
   NODE_ENV: "production"
   NEXT_TELEMETRY_DISABLED: "1"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: banking-ai-config
+  namespace: banking-app
+  labels:
+    app.kubernetes.io/name: banking-app
+    app.kubernetes.io/component: config
+    app.kubernetes.io/service: ai-service
+data:
+  # Python OTel uses http/protobuf to the otel-collector (same shape the
+  # frontend uses) — the SDK appends /v1/traces itself when given the base URL,
+  # but the exporter we pass in main.py is explicit.
+  OTEL_SERVICE_NAME: "ai-service"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.observability:4318"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_TRACES_EXPORTER: "otlp"
+  OTEL_METRICS_EXPORTER: "none"
+  OTEL_LOGS_EXPORTER: "none"
+  OTEL_TRACES_SAMPLER: "always_on"
+  OTEL_PROPAGATORS: "tracecontext"
+  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app"

--- a/kubernetes/base/deployments/ai-service-deployment.yaml
+++ b/kubernetes/base/deployments/ai-service-deployment.yaml
@@ -30,6 +30,9 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        envFrom:
+        - configMapRef:
+            name: banking-ai-config
         env:
         - name: AI_API_KEY
           valueFrom:


### PR DESCRIPTION
## Problem

The Errors dashboard's 'View traces' drill-down opens Jaeger, but ai-service wasn't in the services dropdown — Python/FastAPI had no OTel instrumentation. Java services were already shipping spans via the Spring Boot OTel agent → otel-collector at :4317 (grpc); frontend ships via :4318 (http/protobuf). ai-service was the only banking-app pod with zero spans.

## Solution

- requirements.txt: add opentelemetry-{api,sdk,exporter-otlp-proto-http,instrumentation-fastapi,instrumentation-httpx} at 1.31.0 / 0.52b0 (newest versions that don't require pkg_resources, which Python 3.12+ pip doesn't ship)
- main.py: init TracerProvider with service.name=ai-service + service.namespace=banking-app, BatchSpanProcessor → OTLP/HTTP at \$OTEL_EXPORTER_OTLP_ENDPOINT/v1/traces. FastAPIInstrumentor auto-spans every /api/chat; HTTPXClientInstrumentor auto-spans every outbound LLM call → traces show the parent + 5 anthropic/openai/gemini/xai/openrouter children
- new banking-ai-config ConfigMap mirroring the frontend's pattern (http/protobuf on :4318); OTEL_METRICS/LOGS_EXPORTER=none (we only ship traces — Prometheus already scrapes /actuator/prometheus)
- ai-service-deployment.yaml: envFrom banking-ai-config

After merge → CI bumps tag → ArgoCD redeploys → ai-service appears in Jaeger services dropdown alongside frontend, api-gateway, accounts-service, transactions-service.

## Checklist

- [x] requirements.txt resolves under Python 3.12 (Dockerfile base) — verified by pip install + main.py import in a fresh venv