### PR TITLE
sim: drop error-injection probability 0.6 → 0.05 (AI hero buried in noise)

### DIFF
--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -35,12 +35,12 @@ data:
   BURST_DURATION_MS: "30000"      # each burst lasts ~30s
   BURST_JITTER_MS: "60000"        # ±60s randomness on interval
 
-  # Error injection — keep the errors board continuously populated for the demo.
-  # Default is a 5% baseline with 2-min spikes at :10/:40, which leaves /create at
-  # ~0% between spikes (you can't reliably point at the 4xx spike on camera). 0.6
-  # runs an unhappy path on most sessions, reproducing the ~25% /create error board
-  # the demo investigates — continuously, not just for 2 minutes twice an hour.
-  ERROR_INJECTION_PROBABILITY: "0.6"
+  # Error injection — light realistic background only. The AI /api/chat 5xx is the
+  # hero on the errors board now; the previous 0.6 (legacy /create-error demo) put
+  # a 5–7% baseline on every panel and buried the hero. 0.05 = a few realistic 4xx
+  # (bad login / missing account) per minute, enough to populate the board, low
+  # enough that AI errors stand out when present.
+  ERROR_INJECTION_PROBABILITY: "0.05"
 
   # User pool configuration
   USER_PREFIX: "sim_user_"


### PR DESCRIPTION
## Problem

Errors dashboard reads 5–7% baseline across the board: 404 missing-account at 0.13/s, 404 \`/api/accounts/{accountId}/balance\` at 0.14/s, 401 \`/api/users/login\` at 0.022/s, etc. That's not a real-world banking error rate — it's the simulation client hitting one of \`{badLogin, expiredToken, missingAccount, serviceUnavailable}\` on 60% of sessions because \`ERROR_INJECTION_PROBABILITY=0.6\` is left over from the previous demo's \`/create\`-error story.

With the AI \`/api/chat\` 5xx as the hero now, this floor of constant 4xx noise buries any actual AI signal on the dashboard.

## Solution

Drop to 0.05 (light, realistic background) — matches the in-code default. Errors board stays populated with a few realistic 4xx per minute, but real server errors (AI chat, fault-injection 500s) now read as visible spikes instead of part of the floor.

## Checklist

- [x] Single-line ConfigMap value change; no code change
- [x] Comment updated to explain why 0.05 (not 0.6) is the right setting now