### PR TITLE
errors dashboard: Recent Traces follows $service (drop hardcoded api-gateway)

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -228,12 +228,12 @@
     },
     {
       "type": "table",
-      "title": "Recent Traces",
-      "description": "Click a trace ID to view spans in Jaeger",
+      "title": "Recent Traces — ${service}",
+      "description": "Recent traces for the selected service. Picks the first $service when multi-select is in use (Jaeger search takes one service per query).",
       "gridPos": {"h": 10, "w": 12, "x": 0, "y": 29},
       "datasource": {"type": "jaeger", "uid": "jaeger"},
       "targets": [
-        {"refId": "A", "datasource": {"type": "jaeger", "uid": "jaeger"}, "queryType": "search", "service": "api-gateway", "operation": "", "tags": "", "minDuration": "", "maxDuration": "", "limit": 20}
+        {"refId": "A", "datasource": {"type": "jaeger", "uid": "jaeger"}, "queryType": "search", "service": "${service}", "operation": "", "tags": "", "minDuration": "", "maxDuration": "", "limit": 20}
       ],
       "options": {"showHeader": true, "cellHeight": "sm"},
       "fieldConfig": {


### PR DESCRIPTION
## Problem

Every row in the "Recent Traces" panel on the Errors dashboard showed `api-gateway` regardless of which service the user came from. The Jaeger search target had `"service":"api-gateway"` hardcoded.

## Solution

Bind to `${service}` so the panel honors whatever the dashboard's Service filter is set to (including the drill-down value passed from Overview's table). Title echoes the active service. Jaeger search takes one service per query, so multi-select "All" picks the first value — documented in the panel description.

## Checklist

- [x] JSON validates
- [x] Tested live Jaeger search: `?service=ai-service` returns 3 traces, `?service=accounts-service` returns 3 traces — single-service search works
