### PR TITLE
ai-service: emoji fallback when all providers fail (restores demo hero)

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -298,10 +298,17 @@ async def chat(req: ChatRequest):
             logger.warning("provider=%s error=%s duration=%dms", r.provider, r.error, r.durationMs)
         else:
             logger.info("provider=%s duration=%dms", r.provider, r.durationMs)
+    # If every provider errored (auth failure, rate limit, etc.), substitute a friendly
+    # fallback so the caller still sees a chat reply rather than a wall of stack traces.
+    # The fallback uses an emoji to draw the eye to the warning — which is also exactly
+    # what trips the Western-locale encoding step below.
+    if all(r.error for r in results):
+        for r in results:
+            r.message = f"⚠️ Assistant temporarily unavailable 💰 — please try again."
     # Encode each reply in the user's locale charset for downstream delivery. If the model
     # replied in a language outside that charset (the "model drifted to another language"
-    # case), this raises UnicodeEncodeError -> 500. Intermittent, per-locale, and invisible
-    # in status/latency metrics until you see the actual reply bytes + the locale.
+    # case, or the fallback emoji above), this raises UnicodeEncodeError -> 500.
+    # Intermittent, per-locale, invisible in status/latency until you see reply bytes + locale.
     charset = LOCALE_CHARSET.get(req.locale, DEFAULT_CHARSET)
     for r in results:
         if r.message:


### PR DESCRIPTION
## Problem

Under sidecar `tls-out`, the Speedscale responder isn't intercepting outbound LLM traffic anymore — the 5 providers return real 401/400 (dummy keys). ai-service handled that gracefully (empty messages, no encoding step), so /api/chat returned 200 across the board. The dashboard Errors-by-Endpoint table no longer shows ai-service at all, and the locale-encoding hero is silent.

## Solution

When every provider errored, substitute a single fallback message containing an emoji. Same UnicodeEncodeError path as before:

- ja-JP / zh-CN / ko-KR (utf-8) → 200
- en-US / es-MX / fr-FR / de-DE (cp1252) → 500 on the emoji

Hero restored, encoding story still ships, and the UX of `/api/chat` becomes "we tried 5 providers, all failed, here's a friendly notice" — more plausible than 5 raw stack-trace strings.
