### PR TITLE
errors dashboard: drill to Jaeger; sim: rebalance AI locales for intermittent 5xx

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -135,7 +135,7 @@
           "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "pointSize": 5, "showPoints": "auto"},
           "unit": "percent",
           "min": 0,
-          "links": [{"title": "View error logs in Loki", "url": "/explore?schemaVersion=1&panes={%22l%22:{%22datasource%22:%22loki%22,%22queries%22:[{%22refId%22:%22A%22,%22expr%22:%22{namespace%3D%5C%22banking-app%5C%22}%20%7C~%20%5C%22(%3Fi)(error|exception|fail|5..%20)%5C%22%22,%22queryType%22:%22range%22}],%22range%22:{%22from%22:%22now-30m%22,%22to%22:%22now%22}}}", "targetBlank": true}]
+          "links": [{"title": "View traces in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22queryType%22:%22search%22,%22service%22:%22${__series.name}%22,%22tags%22:%22%22}],%22range%22:{%22from%22:%22now-30m%22,%22to%22:%22now%22}}}", "targetBlank": true}]
         }
       },
       "options": {"tooltip": {"mode": "multi"}}
@@ -193,7 +193,7 @@
             {"id": "color", "value": {"mode": "continuous-reds"}}
           ]},
           {"matcher": {"id": "byName", "options": "Service"}, "properties": [
-            {"id": "links", "value": [{"title": "View error logs in Loki", "url": "/explore?schemaVersion=1&panes={%22l%22:{%22datasource%22:%22loki%22,%22queries%22:[{%22refId%22:%22A%22,%22expr%22:%22{namespace%3D%5C%22banking-app%5C%22}%20%7C~%20%5C%22(%3Fi)(error|exception|fail|5..%20)%5C%22%22,%22queryType%22:%22range%22}],%22range%22:{%22from%22:%22now-30m%22,%22to%22:%22now%22}}}", "targetBlank": true}]}
+            {"id": "links", "value": [{"title": "View traces in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22queryType%22:%22search%22,%22service%22:%22${__value.text}%22,%22tags%22:%22%22}],%22range%22:{%22from%22:%22now-30m%22,%22to%22:%22now%22}}}", "targetBlank": true}]}
           ]},
           {"matcher": {"id": "byName", "options": "Status"}, "properties": [{"id": "custom.width", "value": 90}]},
           {"matcher": {"id": "byName", "options": "Method"}, "properties": [{"id": "custom.width", "value": 90}]}

--- a/simulation-client/src/client/ApiClient.js
+++ b/simulation-client/src/client/ApiClient.js
@@ -255,14 +255,14 @@ class ApiClient {
   }
 
   async askAIChat(message, token) {
-    // Mixed locales across sessions: most users are en-US (some get smart "—"/curly
-    // quotes from the model = ok under cp1252), a real but minority slice are
-    // ja-JP/es-MX etc. Drives an intermittent, per-locale error pattern on the AI
-    // chat endpoint — the demo's investigation hook.
+    // Mixed locales across sessions. ai-service encodes the assistant reply in the
+    // user's locale charset for downstream delivery: Western locales (cp1252) blow up
+    // on the emoji in the LLM mock reply → 500; Asian locales (utf-8) pass → 200.
+    // Aim for ~55/45 fail/pass so the dashboard reads as intermittent (real-world bug
+    // pattern), not "everything broken".
     const LOCALES = [
-      'en-US','en-US','en-US','en-US','en-US','en-US','en-US',  // ~70%
-      'es-MX','es-MX',                                          // ~20%
-      'ja-JP',                                                  // ~10%
+      'en-US','en-US','es-MX','fr-FR','de-DE','en-US',  // 6 Western → cp1252 → 500
+      'ja-JP','ja-JP','zh-CN','ko-KR',                  // 4 Asian → utf-8 → 200
     ];
     const locale = LOCALES[Math.floor(Math.random() * LOCALES.length)];
     return this.retryRequest(async () => {


### PR DESCRIPTION
## Problems

1. Clicking a row in 'Errors by Endpoint' on the Errors dashboard opened Loki Explore ("Loki query hung" — long-running tail query). It should land on Jaeger for the clicked service.
2. ai-service /api/chat showed ~95% error rate — reads as a total outage, not intermittent.

## Cause

1. PR #189 swapped the row link from Jaeger to Loki because Jaeger didn't have spans for ai-service / user-service / fraud-service / notification-service at the time. After PR #190 wired up OTel on ai-service, every banking-* service has spans now, so the Loki workaround is obsolete.
2. Sim locale mix was 7×en-US + 2×es-MX + 1×ja-JP → 90% Western (cp1252) → 500 on emoji. Adjusted to 6×Western + 4×Asian for a ~55/45 fail/pass that reads as a real intermittent bug.

## Solution

- 'Errors by Endpoint' row link: bind `service` to `${__value.text}` (clicked service) → Jaeger Explore
- 'Error Rate by Service' series link: bind `service` to `${__series.name}` (hovered series) → Jaeger Explore
- Sim `LOCALES` array: 6 Western (en-US×3, es-MX, fr-FR, de-DE) + 4 Asian (ja-JP×2, zh-CN, ko-KR)
