### PR TITLE
notification responder: repoint to fresh snapshot (live signature match)

### DIFF
--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -4,7 +4,19 @@ metadata:
   name: replay-banking-notification
   namespace: banking-app
 spec:
-  snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
+  # Repointed 2026-06-17 from snapshot ae1d6748 → 13301da0 after a diagnostic
+  # pull (proxymock pull_remote_recording service=banking-notification) showed
+  # the in-repo snapshot's Twilio Account SID + Slack webhook token didn't
+  # match what the live notification service is sending. Responder matches on
+  # host+method+path byte-for-byte → was 16 NO_MATCH passthroughs/min on
+  # Twilio + Slack (Sendgrid /v3/mail/send is constant and matched both ways).
+  #
+  # 13301da0 is a fresh pull of the live traffic: 164 outbound RRPairs
+  # covering all 3 hosts with the current signatures. To redo if the env
+  # changes scrubber output again:
+  #   speedctl pull snapshot --clone <existing>  (or pull_remote_recording)
+  #   update snapshotID below + commit
+  snapshotID: 13301da0-f2ec-43db-a06e-79f44ef09797
   testConfigID: banking-mock-noproxy
   mode: responder-only
   workloadRef:


### PR DESCRIPTION
## Problem

`replay-banking-notification` was the only responder leaking. ~16 NO_MATCH passthroughs/min — outbound to Twilio + Slack escaped the cluster (Sendgrid matched fine because its path is constant).

## Diagnostic

Pulled current live notification traffic via `proxymock pull_remote_recording service=banking-notification` → fresh snapshot `13301da0-f2ec-43db-a06e-79f44ef09797` with 164 outbound RRPairs (56 slack + 56 sendgrid + 52 twilio). Compared signatures vs the in-use snapshot:

- Twilio: account identifier in path differs between the two
- Slack: webhook token differs
- Sendgrid: matched (constant path)

Different scrubber output between the two recordings — the original was captured against an older env. Responder matching is exact byte-for-byte on the URL path, so even a one-character diff sinks it.

## Solution

Repoint the TR `snapshotID` to the fresh snapshot. Same shape, same operator config, same responder behavior — just with the signatures the live service actually sends.

## Checklist

- [x] Fresh snapshot covers all 3 hosts (52 / 56 / 56)
- [x] Comment in the YAML preserves the diff context + the exact `proxymock pull_remote_recording` recipe to redo this if scrubber tokens drift again
