### PR TITLE
notification: SLACK_WEBHOOK_URL 3-segment override for responder match

### DIFF
--- a/kubernetes/overlays/speedscale/notification-service-thirdparty-env.yaml
+++ b/kubernetes/overlays/speedscale/notification-service-thirdparty-env.yaml
@@ -24,8 +24,14 @@ spec:
             secretKeyRef:
               name: banking-thirdparty-keys
               key: TWILIO_AUTH_TOKEN
+        # SLACK_WEBHOOK_URL: literal override that paves the URL into a 3-segment
+        # path so the banking-notification responder snapshot's `hooks.slack.com`
+        # http_url scrubs at index 1, 2, and 3 all fire (they need a segment to
+        # scrub or the chain becomes a no-op). With this, both recorded
+        # `/services/<team>/<bot>/<token>` and live `/services/SET/VIA/SECRET`
+        # normalize to `/services/*/*/*` and signature-match cleanly. Sealed
+        # secret value was a 1-segment placeholder (`/services/SET-VIA-SECRET`)
+        # — leaving it alone for the other environments; only the speedscale
+        # overlay needs the 3-segment shape.
         - name: SLACK_WEBHOOK_URL
-          valueFrom:
-            secretKeyRef:
-              name: banking-thirdparty-keys
-              key: SLACK_WEBHOOK_URL
+          value: "https://hooks.slack.com/services/SET/VIA/SECRET"


### PR DESCRIPTION
## Problem

`replay-banking-notification` was the only responder leaking — ~16 NO_MATCH per minute on slack outbound.

## Root cause

The responder snapshot (`ae1d6748`) has scrub chains on `hooks.slack.com` http_url at indices 1, 2, and 3 to wildcard the team / bot / token URL segments. Each scrub is a no-op when its target segment doesn't exist, so the chains need a 3-segment URL to fully fire.

The sealed-secret value was a single-segment placeholder `https://hooks.slack.com/services/SET-VIA-SECRET`:

- Live URL: `/services/SET-VIA-SECRET` → after scrubs: `/services/*` (only index 1 scrubbed, index 2/3 no-op)
- Recorded URL: `/services/<team>/<bot>/<token>` → after scrubs: `/services/*/*/*` (all three scrubbed)

Different segment counts in the normalized signature → mismatch → passthrough.

## Solution

Speedscale-overlay-only literal env override: `https://hooks.slack.com/services/SET/VIA/SECRET` (same three innocuous words, slashes instead of dashes). Both live and recorded URLs now normalize to `/services/*/*/*` and the existing scrub chains do the rest.

## Cloud-side changes (no repo diff)

- `banking-mocks` transform set: added `hooks.slack.com http_url index=1` and `index=2` scrub chains (previously only index=3) via `speedctl push transform`
- snapshot `ae1d6748` tokenizerConfig.responder: 10 → 12 chains via `speedctl edit snapshot … && speedctl push snapshot --force`

## Verification

```
kubectl patch secret banking-thirdparty-keys --type=json … (SLACK_WEBHOOK_URL → 3-segment)
kubectl rollout restart deploy/banking-notification
# bounce responder pod so it reloads 12 chains
NO MATCH count over last 60s: 0
```

(was 15/min before)

## Checklist

- [x] Sealed secret untouched (still works for non-speedscale environments)
- [x] Comment in YAML captures why the override is needed
- [x] Both cloud-side companion changes documented in commit message for future re-apply
