### PR TITLE
postsync reroll: switch image to alpine/k8s (bitnami/kubectl:1.30 gone)

### DIFF
--- a/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
+++ b/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
@@ -85,7 +85,10 @@ spec:
       restartPolicy: Never
       containers:
       - name: reroll
-        image: bitnami/kubectl:1.30
+        # bitnami/kubectl:1.30 doesn't exist on Docker Hub (Broadcom pulled the
+        # Bitnami catalog). alpine/k8s:1.34.0 matches the staging-decoy server
+        # version (v1.34.8) and ships kubectl + bash.
+        image: alpine/k8s:1.34.0
         command: ["/bin/bash", "-c"]
         args:
         - |


### PR DESCRIPTION
## Problem

PR #195 added a PostSync Job using `image: bitnami/kubectl:1.30`. That tag doesn't exist on Docker Hub — Broadcom pulled the public Bitnami image catalog. The Job has been sitting in `ImagePullBackOff` for 41 minutes since #195 merged. As a result, banking-ai's TR-to-workload binding desynced again (operator showed `IsSUT: false`, `ActiveReplayEnvId: ""`), the new banking-ai pod was created without the responder init container, and outbound LLM traffic escaped the cluster → no chat 5xx → demo hero silent.

## Solution

Switch the image to `alpine/k8s:1.34.0` — matches the staging-decoy server version (v1.34.8) and ships kubectl + bash, same surface the reroll script needs.

## Checklist

- [x] Confirmed alpine/k8s:1.34.0 exists on Docker Hub
- [x] No other changes to the Job script
