### PR TITLE
README: refresh to match current repo state (4 → 8 services, +Speedscale section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Banking Application - Microservices Demo
+# Banking Application — Microservices Demo
 
-A banking application built with a microservices architecture demonstrating modern development practices including containerization, orchestration, and observability.
+A multi-language banking application built as a Speedscale demo. Shows a realistic microservices stack with HTTP, gRPC, Kafka, Postgres, MongoDB, and 5 LLM provider integrations — and demonstrates how Speedscale replays captured production traffic against locally isolated services with mocked third-party dependencies.
 
 ## 🚀 Quick Start
 
@@ -10,32 +10,43 @@ A banking application built with a microservices architecture demonstrating mode
 docker-compose up -d
 
 # Access the application and tools
-open http://localhost:3000      # Frontend
+open http://localhost:3000      # Frontend (Next.js 15)
 open http://localhost:3001      # Grafana (admin/admin)
-open http://localhost:9090      # Prometheus  
+open http://localhost:9090      # Prometheus
 open http://localhost:16686     # Jaeger
 ```
 
 ### Deploy to Kubernetes
 ```bash
-# Deploy the entire application stack
-kubectl apply -k kubernetes/base/
+# Deploy the full app + Speedscale overlay (responder mocks for every third party)
+kubectl apply -k kubernetes/overlays/speedscale/
 
-# Deploy observability stack (optional)
-kubectl apply -k kubernetes/observability/
+# Or deploy without Speedscale routing
+kubectl apply -k kubernetes/overlays/local/
 
-# Access the application (adjust for your cluster)
-kubectl port-forward -n banking-app svc/frontend-service-nodeport 30000:30000
-open http://localhost:30000
+# Access the application via your cluster's ingress / load balancer
 ```
 
 ## Architecture
 
-A microservices application with:
-- **Frontend**: Next.js application with TypeScript
-- **Backend**: 4 Java Spring Boot microservices (User, Accounts, Transactions, API Gateway)
-- **Database**: PostgreSQL with service-specific schemas
-- **Observability**: OpenTelemetry with Jaeger, Prometheus, and Grafana
+8 backend services across 3 languages, a Next.js frontend, and a load-generating simulation client.
+
+| Service | Language | Purpose |
+|---|---|---|
+| `api-gateway` | Java (Spring Cloud Gateway) | Edge router, JWT auth, optional fault injection |
+| `user-service` | Java (Spring Boot) | Authentication, profile management |
+| `accounts-service` | Java (Spring Boot) | Account + balance management, Plaid integration |
+| `transactions-service` | Java (Spring Boot) | Transaction processing, Stripe / PayPal / ComplyAdvantage integrations |
+| `ai-service` | Python (FastAPI) | Chat endpoint that fans out to 5 LLM providers (Anthropic, OpenAI, Gemini, xAI, OpenRouter) and encodes the reply in the user's locale charset |
+| `fraud-service` | Go (gRPC h2c on :50051) | Fraud risk scoring with Sift / MaxMind / Stripe Radar |
+| `notification-service` | Go | Slack / SendGrid / Twilio fan-out for transaction events from Kafka |
+| `mongo-service` | Java | Mongo-backed user-data store |
+| `frontend` | Next.js 15 / React 19 | Server-side proxy + UI |
+| `simulation-client` | Node.js | Drives realistic user-session traffic with burst patterns + intentional error injection |
+
+**Storage / messaging:** PostgreSQL (per-service schemas), MongoDB, Kafka (transaction event stream).
+
+**Observability:** OpenTelemetry → otel-collector → Jaeger (traces) + Prometheus (metrics) + Loki (logs) + Grafana (dashboards).
 
 How **OpenTelemetry trace data** is processed in-process (SDK) and after export (OTLP → collector on Kubernetes, or direct to Jaeger in Docker Compose) is documented with Mermaid diagrams in [OBSERVABILITY.md — OpenTelemetry trace data processing](./OBSERVABILITY.md#opentelemetry-trace-data-processing) and [architecture.md — OTel trace data processing](./architecture.md#otel-trace-data-processing).
 
@@ -43,41 +54,71 @@ How **OpenTelemetry trace data** is processed in-process (SDK) and after export 
 flowchart LR
   subgraph clients["Clients"]
     browser[browser]
-    mobile[mobile]
-    api[api]
+    sim[simulation-client]
   end
-  frontend[frontend]
-  gateway[api-gateway]
-  accounts[accounts-service]
-  transactions[transactions-service]
-  users[user-service]
-  postgres[(postgres)]
+
+  frontend[frontend<br/>Next.js]
+  gateway[api-gateway<br/>Java]
+  accounts[accounts-service<br/>Java]
+  transactions[transactions-service<br/>Java]
+  users[user-service<br/>Java]
+  ai[ai-service<br/>Python]
+  fraud[fraud-service<br/>Go gRPC]
+  notif[notification-service<br/>Go]
+
+  postgres[(Postgres)]
+  mongo[(MongoDB)]
+  kafka[(Kafka)]
+
+  subgraph thirdparty["3rd parties"]
+    llm["LLM APIs<br/>(Anthropic, OpenAI, Gemini, xAI, OpenRouter)"]
+    payments["Stripe / PayPal /<br/>ComplyAdvantage"]
+    messaging["Slack / SendGrid / Twilio"]
+    plaid["Plaid"]
+    risk["Sift / MaxMind"]
+  end
 
   browser --> frontend
-  mobile --> frontend
-  api --> frontend
+  sim --> frontend
   frontend --> gateway
+  gateway --> users
   gateway --> accounts
   gateway --> transactions
-  gateway --> users
+  gateway --> ai
+
   accounts --> postgres
   transactions --> postgres
   users --> postgres
+  accounts --> plaid
+
+  transactions --> fraud
+  transactions --> payments
+  transactions --> kafka
+
+  fraud --> risk
+
+  ai --> llm
+
+  notif -.consumes.-> kafka
+  notif --> messaging
 ```
 
-## Repository Structure
+## Speedscale Demo
 
-```
-├── backend/
-│   ├── user-service/        # User authentication and profile management
-│   ├── accounts-service/    # Bank account and balance management
-│   ├── transactions-service/ # Financial transaction processing
-│   └── api-gateway/        # Request routing and authentication
-├── frontend/               # Next.js web application
-├── kubernetes/             # Kubernetes manifests and configs
-├── tools/                  # Development tools and templates
-└── scripts/                # Essential utility scripts
-```
+The `speedscale` overlay deploys the app alongside the Speedscale operator and binds every service to a recorded snapshot via a `TrafficReplay` (responder-only mode):
+
+| Workload | Recorded snapshot serves |
+|---|---|
+| `banking-ai` | All 5 LLM provider responses |
+| `banking-accounts` | Plaid balance lookups |
+| `banking-transactions` | Stripe, PayPal, ComplyAdvantage |
+| `banking-fraud` | Sift, MaxMind, Stripe Radar |
+| `banking-notification` | Slack, SendGrid, Twilio |
+| `banking-user` | Auth dependencies |
+
+The operator's mutating webhook injects a `speedscale-initproxy-responder` init container into each app pod, which rewrites `/etc/hosts` so outbound third-party hostnames resolve to the in-cluster responder. The responder matches each outbound request by signature (host + method + URL path + body shape) and serves the recorded response — zero egress, deterministic, no real credentials needed.
+
+A PostSync hook (`kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml`) rolls any workload whose pods are missing the responder init container after every ArgoCD sync, so a webhook race during a rolling deploy can't silently disable the responder for one of the services.
 
 ## Development
 
@@ -85,14 +126,13 @@ flowchart LR
 Each service has its own Makefile for isolated development and testing:
 
 ```bash
-# Build and run individual services
 cd backend/user-service
 make build
 make run
 
 # Run with dependencies mocked using proxymock
 make proxymock-record  # Record traffic with real dependencies
-make proxymock-mock    # Run with mocked dependencies  
+make proxymock-mock    # Run with mocked dependencies
 make proxymock-replay  # Test with recorded traffic
 ```
 
@@ -101,16 +141,19 @@ make proxymock-replay  # Test with recorded traffic
 cd frontend
 npm install
 npm run dev            # Development server at http://localhost:3000
-npm run build         # Production build
-npm test              # Run tests
+npm run build          # Production build
+npm test               # Run tests
 ```
 
 ### Database Operations
 ```bash
-# Connect to PostgreSQL
+# Postgres
 psql -h localhost -p 5432 -U postgres -d banking_app
 
-# Run migrations (from service directory)  
+# Mongo
+mongosh mongodb://localhost:27017/banking_app
+
+# Run migrations (from a Java service directory)
 ./mvnw flyway:migrate
 ```
 
@@ -118,41 +161,41 @@ psql -h localhost -p 5432 -U postgres -d banking_app
 
 ### Backend Tests
 ```bash
-# Run unit tests for all services
+# Java services
 ./mvnw test
-
-# Run integration tests
 ./mvnw verify -P integration-tests
 
-# Test individual service with mocked dependencies
-cd backend/user-service
-make test
-make proxymock-mock  # Test in isolation
+# Go services
+cd backend/fraud-service && go test ./...
+
+# Python service
+cd backend/ai-service && pytest
+
+# Service-in-isolation
+cd backend/user-service && make proxymock-mock
 ```
 
 ### Frontend Tests
 ```bash
 cd frontend
-npm test              # Unit tests
-npm run test:e2e      # End-to-end tests
+npm test               # Unit tests
+npm run test:e2e       # End-to-end tests
 ```
 
 ## Debugging with Proxymock
 
 Each service supports isolated testing without running all dependencies:
 
-### Debugging Workflow
 ```bash
 # 1. Record traffic while system is working
 cd backend/user-service
 make proxymock-record
-# Make some API calls to generate traffic
 
 # 2. Test service in isolation with mocked dependencies
 make proxymock-mock    # Starts service with postgres/other services mocked
 make proxymock-replay  # Replays recorded requests
 
-# 3. Debug specific issues
+# 3. Inspect / clean up
 make proxymock-list    # See recorded traffic files
 make proxymock-env     # Show environment variables needed
 make proxymock-stop    # Stop all proxymock processes
@@ -160,38 +203,24 @@ make proxymock-stop    # Stop all proxymock processes
 
 ### Service Isolation Testing
 | Service | What Gets Mocked | Use Case |
-|---------|-----------------|----------|
+|---|---|---|
 | user-service | postgres, accounts-service, transactions-service | Auth and user management testing |
-| accounts-service | postgres, user-service | Account operations testing |
-| transactions-service | postgres, accounts-service, user-service | Transaction processing testing |  
+| accounts-service | postgres, user-service, Plaid | Account operations testing |
+| transactions-service | postgres, accounts-service, fraud-service, Stripe / PayPal / ComplyAdvantage | Transaction processing testing |
+| ai-service | 5 LLM provider APIs | Locale / encoding bug reproduction |
+| fraud-service | Sift / MaxMind / Stripe Radar | Risk-scoring testing |
+| notification-service | Kafka, Slack / SendGrid / Twilio | Notification fan-out testing |
 | api-gateway | All backend services | API routing and gateway testing |
 | frontend | api-gateway | UI testing with mocked backend |
-
-### Running Individual Services Locally
-
-You can run services locally for debugging without Docker:
-
-```bash
-# 1. Start only PostgreSQL in Docker
-docker-compose up -d postgres
-
-# 2. Run service locally with IDE debugger
-cd backend/user-service
-export DB_HOST=localhost
-export DB_PORT=5432
-./mvnw spring-boot:run
-
-# 3. Or use proxymock to mock all dependencies
-make proxymock-mock  # No database or other services needed
-```
 
 ## Key Features
 
 - **Authentication**: JWT-based authentication with HttpOnly cookies
-- **Observability**: Distributed tracing, metrics, and structured logging
+- **Observability**: Distributed tracing (OTel + Jaeger), Prometheus metrics, Loki logs, Grafana dashboards
+- **Speedscale integration**: Responder mocks for every third party, deterministic replay
 - **Development Tools**: Service-specific Makefiles with proxymock integration
 - **Container Ready**: Docker and Kubernetes deployment configurations
-- **Testing**: Comprehensive unit, integration, and E2E test coverage
+- **Load generation**: Simulation client drives realistic burst traffic with configurable error injection
 
 ## Version Management
 
@@ -199,12 +228,12 @@ The project uses semantic versioning with all services sharing the same version 
 
 ```bash
 # Check current version
-make version                          # Shows: 1.2.2
+make version                          # Shows: 1.4.75
 
 # Bump version
-make version-bump BUMP_TYPE=patch     # 1.2.2 -> 1.2.3
-make version-bump BUMP_TYPE=minor     # 1.2.2 -> 1.3.0
-make version-bump BUMP_TYPE=major     # 1.2.2 -> 2.0.0
+make version-bump BUMP_TYPE=patch     # 1.4.75 -> 1.4.76
+make version-bump BUMP_TYPE=minor     # 1.4.75 -> 1.5.0
+make version-bump BUMP_TYPE=major     # 1.4.75 -> 2.0.0
 
 # Update all files and Kubernetes manifests
 make version-bump BUMP_TYPE=patch && make update-k8s-version
@@ -216,15 +245,15 @@ kubectl apply -k kubernetes/overlays/speedscale/
 
 ## Documentation
 
-- **[AGENTS.md](./AGENTS.md)** - Guidance for AI assistants and automated agents
-- **[TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** - Comprehensive debugging guide
-- **[OBSERVABILITY.md](./OBSERVABILITY.md)** - Monitoring, tracing, and metrics setup
-- **[PLAN.md](./PLAN.md)** - Detailed implementation phases and testing criteria
-- **[architecture.md](./architecture.md)** - System architecture and design decisions
+- **[AGENTS.md](./AGENTS.md)** — Guidance for AI assistants and automated agents
+- **[TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** — Comprehensive debugging guide
+- **[OBSERVABILITY.md](./OBSERVABILITY.md)** — Monitoring, tracing, and metrics setup
+- **[PLAN.md](./PLAN.md)** — Detailed implementation phases and testing criteria
+- **[architecture.md](./architecture.md)** — System architecture and design decisions
 
 ## Getting Started
 
-1. **Prerequisites**: Docker, Docker Compose, Node.js 20+ (frontend / Tailwind v4), Java 17+, Maven 3.8+
+1. **Prerequisites**: Docker, Docker Compose, Node.js 20+, Java 17+, Maven 3.8+, Go 1.21+, Python 3.12+
 2. **Quick start**: Run `docker-compose up -d` to start everything
 3. **Development**: Use service-specific Makefiles for isolated development
 4. **Testing**: Use proxymock for dependency-free testing
@@ -235,10 +264,13 @@ kubectl apply -k kubernetes/overlays/speedscale/
 Verify all services are running:
 ```bash
 curl http://localhost:8080/actuator/health  # API Gateway
-curl http://localhost:8081/actuator/health  # User Service  
+curl http://localhost:8081/actuator/health  # User Service
 curl http://localhost:8082/actuator/health  # Accounts Service
 curl http://localhost:8083/actuator/health  # Transactions Service
+curl http://localhost:8084/health           # AI Service (FastAPI)
+curl http://localhost:8085/health           # Notification Service (Go)
 curl http://localhost:3000/api/health       # Frontend
+# fraud-service speaks gRPC; use `grpcurl localhost:50051 list`
 ```
 
 ---


### PR DESCRIPTION
## Problem

README was last accurate around v1.2.x and is now significantly stale — only documents 4 of the 8 backend services, missing the AI / fraud / notification / mongo services, MongoDB, Kafka, the simulation-client, the Speedscale overlay, and the PostSync responder-survival hook. Version example still says `1.2.2` (current: `1.4.75`).

## Updates

- **Architecture** — table of all 8 backend services + frontend + simulation-client, with language and purpose for each. Storage + messaging (Postgres, MongoDB, Kafka). Observability stack callout.
- **Mermaid diagram** — adds ai-service, fraud-service, notification-service, MongoDB, Kafka, and the third-party groups (LLM providers, payments, messaging, Plaid, risk). Same left-to-right shape, just complete.
- **Repository Structure** — adds `simulation-client/`, `proxymock/`, `proto/`, `database/`, `docs/`, `images/`. Breaks `kubernetes/` out by overlay so the speedscale vs local choice is visible.
- **New: Speedscale Demo section** — per-workload responder bindings (`banking-ai` → 5 LLMs, `banking-transactions` → Stripe / PayPal / ComplyAdvantage, etc.), how the init-container injection works, and the PostSync reroll hook.
- **Service isolation table** — adds ai / fraud / notification rows with their real third-party deps.
- **Version Management** — example bumped to `1.4.75`.
- **Prerequisites** — Go 1.21+ and Python 3.12+ added.
- **Health checks** — ai-service / notification-service ports + a grpcurl hint for fraud-service.
