### PR TITLE
errors dashboard: Recent Requests by Status with color-coded column

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-errors.json
+++ b/kubernetes/observability/dashboards/banking-app-errors.json
@@ -228,27 +228,43 @@
     },
     {
       "type": "table",
-      "title": "Recent Traces — ${service}",
-      "description": "Recent traces for the selected service. Picks the first $service when multi-select is in use (Jaeger search takes one service per query).",
+      "title": "Recent Requests by Status — ${service}",
+      "description": "Per-endpoint request count over the last 5 minutes, broken out by HTTP status. Status column is colored green / orange / red for 2xx / 4xx / 5xx so good and bad calls are differentiated at a glance. Click the Service cell to open Jaeger filtered to that service.",
       "gridPos": {"h": 10, "w": 12, "x": 0, "y": 29},
-      "datasource": {"type": "jaeger", "uid": "jaeger"},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"refId": "A", "datasource": {"type": "jaeger", "uid": "jaeger"}, "queryType": "search", "service": "${service}", "operation": "", "tags": "", "minDuration": "", "maxDuration": "", "limit": 20}
+        {"expr": "sum by (job, method, uri, status) (increase(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))", "format": "table", "instant": true, "refId": "A"}
       ],
-      "options": {"showHeader": true, "cellHeight": "sm"},
+      "transformations": [
+        {"id": "organize", "options": {
+          "excludeByName": {"Time": true},
+          "renameByName": {"job": "Service", "method": "Method", "uri": "Endpoint", "status": "Status", "Value": "Count (5m)"}
+        }},
+        {"id": "sortBy", "options": {"fields": {}, "sort": [{"field": "Count (5m)", "desc": true}]}}
+      ],
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "custom": {"align": "auto", "filterable": true, "cellOptions": {"type": "auto"}},
+          "decimals": 0
+        },
         "overrides": [
-          {
-            "matcher": {"id": "byName", "options": "Trace ID"},
-            "properties": [
-              {"id": "links", "value": [
-                {"title": "Open in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22query%22:%22${__value.text}%22}],%22range%22:{%22from%22:%22now-1h%22,%22to%22:%22now%22}}}", "targetBlank": true}
-              ]}
-            ]
-          }
+          {"matcher": {"id": "byName", "options": "Status"}, "properties": [
+            {"id": "custom.width", "value": 90},
+            {"id": "custom.cellOptions", "value": {"type": "color-background", "mode": "basic"}},
+            {"id": "thresholds", "value": {"mode": "absolute", "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 400},
+              {"color": "red", "value": 500}
+            ]}}
+          ]},
+          {"matcher": {"id": "byName", "options": "Method"}, "properties": [{"id": "custom.width", "value": 90}]},
+          {"matcher": {"id": "byName", "options": "Count (5m)"}, "properties": [{"id": "custom.width", "value": 110}]},
+          {"matcher": {"id": "byName", "options": "Service"}, "properties": [
+            {"id": "links", "value": [{"title": "View traces in Jaeger", "url": "/explore?schemaVersion=1&panes={%22j%22:{%22datasource%22:%22jaeger%22,%22queries%22:[{%22refId%22:%22A%22,%22queryType%22:%22search%22,%22service%22:%22${__value.text}%22,%22tags%22:%22%22}],%22range%22:{%22from%22:%22now-30m%22,%22to%22:%22now%22}}}", "targetBlank": true}]}
+          ]}
         ]
-      }
+      },
+      "options": {"showHeader": true, "cellHeight": "sm", "footer": {"show": false}}
     },
     {
       "type": "logs",


### PR DESCRIPTION
## Problem

The 'Recent Traces' panel on the Errors dashboard is powered by Grafana's Jaeger search query. Jaeger's plugin returns a fixed set of columns (Trace ID, name, Start, Duration) — there's no way to add HTTP status code as a column. So you can't tell from the dashboard which recent traces are good vs. bad calls without clicking each one.

## Solution

Replace the panel with a Prometheus table that reads from the same `http_server_requests_seconds_count` metric every service exports. Group by `(job, method, uri, status)` over the last 5 minutes — Status is then a first-class column, color-coded:

- 2xx → **green**
- 4xx → **orange**
- 5xx → **red**

Click the Service cell to open Jaeger Explore filtered to that service for traditional trace drill-down.

Works uniformly across Java / Python / Go services since they all feed the same Prometheus metric — no per-service log-format parsing.

## Checklist

- [x] JSON validates
- [x] Sortable by Count (5m) desc so highest-volume routes surface first
- [x] Service cell links into Jaeger Explore for trace drill-down (keeps the click-through value of the old panel)
