### PR TITLE
README: drop residual 'locale charset' description from ai-service row

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ kubectl apply -k kubernetes/overlays/local/
 | `user-service` | Java (Spring Boot) | Authentication, profile management |
 | `accounts-service` | Java (Spring Boot) | Account + balance management, Plaid integration |
 | `transactions-service` | Java (Spring Boot) | Transaction processing, Stripe / PayPal / ComplyAdvantage integrations |
-| `ai-service` | Python (FastAPI) | Chat endpoint that fans out to 5 LLM providers (Anthropic, OpenAI, Gemini, xAI, OpenRouter) and encodes the reply in the user's locale charset |
+| `ai-service` | Python (FastAPI) | Chat endpoint that fans out to 5 LLM providers (Anthropic, OpenAI, Gemini, xAI, OpenRouter) and aggregates the replies |
 | `fraud-service` | Go (gRPC h2c on :50051) | Fraud risk scoring with Sift / MaxMind / Stripe Radar |
 | `notification-service` | Go | Slack / SendGrid / Twilio fan-out for transaction events from Kafka |
 | `mongo-service` | Java | Mongo-backed user-data store |

--- a/simulation-client/src/workflows/UserWorkflow.js
+++ b/simulation-client/src/workflows/UserWorkflow.js
@@ -574,11 +574,9 @@ class UserWorkflow {
 
     const account = user.accounts && user.accounts.length > 0 ? user.accounts[0] : null;
 
-    // Weighted scenario selection — pick from a bag with repeats. Light background noise only;
-    // the hero error for the demo is the AI locale/encoding 5xx, which arises from normal /api/chat
-    // traffic when a provider reply drifts to a language outside the user's locale charset (not a
-    // bag scenario). Keep these minor so none dominates the errors board. Transaction-error
-    // scenarios (overdraw -> $100M 400) remain deferred with the transactions/fraud reproduce.
+    // Weighted scenario selection — pick from a bag with repeats. Light background
+    // noise only; the bigger errors are driven by normal /api/chat traffic, not by
+    // this bag. Keep entries here minor so none dominates the errors board.
     const bag = [
       'missingAccount',                                      // 404 /api/accounts/{id}/balance (a few, not dominant)
       'serviceUnavailable',                                  // 503 /api/accounts/{id}/export-statement


### PR DESCRIPTION
## Missed in PR #199

Last leak the AI investigation could pattern-match on. The architecture-table description for ai-service still said "encodes the reply in the user's locale charset" — which, next to "5 LLM providers", reads as exactly the locale-encoding bug. Drop the locale-charset half, keep the neutral "aggregates the replies".

After this, repo-wide grep for `cp1252 | charmap | UnicodeEncodeError | locale charset` only hits `backend/ai-service/delivery.py` — which is where the Jaeger stack trace already points, so the demo flow is unchanged.
