### PR TITLE
postsync reroll: poll the actual TR Running condition (not .statusName)

### DIFF
--- a/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
+++ b/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
@@ -12,7 +12,7 @@
 # traffic escapes the cluster — exactly the failure mode we hit on 2026-06-17.
 #
 # This hook:
-#   1. Polls every TR in banking-app until all show statusName=Running
+#   1. Polls every TR in banking-app until conditions[Running].status=True
 #      (operator settles within ~60s after pods come up)
 #   2. Issues `kubectl rollout restart` on each banking workload
 #   3. Waits for each rollout to complete (new pods, each with the responder
@@ -102,8 +102,12 @@ spec:
           for i in {1..60}; do
             running=0
             for tr in "${TRS[@]}"; do
-              s=$(kubectl -n "$NS" get trafficreplay "$tr" -o jsonpath='{.status.statusName}' 2>/dev/null || echo "")
-              if [[ "$s" == "Running" ]]; then running=$((running+1)); fi
+              # The TR CRD does not expose .status.statusName; the printer-column
+              # "Status" shown in `kubectl get trafficreplay` reads from
+              # .status.conditions[-1:].message. Check the Running condition's
+              # `status` field directly — that's the authoritative signal.
+              s=$(kubectl -n "$NS" get trafficreplay "$tr" -o jsonpath='{.status.conditions[?(@.type=="Running")].status}' 2>/dev/null || echo "")
+              if [[ "$s" == "True" ]]; then running=$((running+1)); fi
             done
             echo "[$(date -u +%FT%TZ)]   ${running}/${#TRS[@]} TRs Running"
             if [[ "$running" -eq "${#TRS[@]}" ]]; then break; fi


### PR DESCRIPTION
## Problem

PR #195 polled `.status.statusName` on each TrafficReplay, but the TR CRD doesn't expose that field — kubectl always returned an empty string, so the wait loop saw 0/6 TRs as Running every iteration and ran the full 60 × 5s sleep before the "rolling anyway" fallback kicked in.

Result: every ArgoCD PostSync hook spent ~5 minutes blocked on the wait loop. That chained into a sync backlog — workload image bumps from #200, #201, #203 didn't actually roll out (deployments still at v1.4.74 even though master is at v1.4.81), and pods were running stale code (e.g. sim's 60/40 locale mix + retryRequest still active → 76% AI chat error rate instead of the targeted ~20%).

## Solution

The "Status" column in `kubectl get trafficreplay` is actually backed by `.status.conditions[-1:].message`. Query the canonical Running condition directly:

```
.status.conditions[?(@.type=="Running")].status
```

Returns `True` / `False` / empty — match on `True`.

Same loop, same fallback, same exit semantics. The script just now actually checks the right field, so a healthy cluster passes the wait phase in a few seconds instead of 5 minutes.

## Checklist

- [x] jsonpath verified live against TR
- [x] Comment in the YAML explains why `.status.statusName` was the wrong field
