### PR TITLE
ai-service: emit Python ProcessCollector + PlatformCollector

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -14,6 +14,8 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Histogram, generate_latest
+from prometheus_client.process_collector import ProcessCollector
+from prometheus_client.platform_collector import PlatformCollector
 from pydantic import BaseModel
 
 from delivery import prepare_for_delivery
@@ -46,6 +48,12 @@ app.add_middleware(
 # panels alongside the Java services. Histogram (not Counter) so the exposed series is named
 # http_server_requests_seconds_count — without prometheus_client's automatic `_total` suffix.
 _metrics_registry = CollectorRegistry()
+# Standard process / runtime metrics so dashboards that show CPU + memory across
+# every service (not just JVM ones) have data for ai-service. Emits
+# process_cpu_seconds_total, process_resident_memory_bytes, process_open_fds,
+# python_info, etc.
+ProcessCollector(registry=_metrics_registry)
+PlatformCollector(registry=_metrics_registry)
 _HTTP_REQUESTS = Histogram(
     "http_server_requests_seconds",
     "HTTP server requests (Micrometer-compatible)",


### PR DESCRIPTION
# Problem

ai-service had no process-level metrics (CPU seconds, RSS, open FDs, python_info). Java services get this for free via Micrometer; Python services need explicit registration.

# Solution

Register `ProcessCollector` + `PlatformCollector` on ai-service's prometheus registry. Emits the standard `process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_open_fds`, `python_info` series.

The original dashboard half of this PR was superseded by #207 (node-level tiles via node-exporter `system_cpu_usage` / `node_memory_*`), so that piece was dropped on rebase. This PR is now just the ai-service code change.

## Checklist

- [x] Tests pass
- [x] Manually verified
- [x] No public API change