### PR TITLE
observability: node-exporter + kubelet cAdvisor scrape (node + per-container metrics)

### DIFF
--- a/kubernetes/observability/dashboards/banking-app-health.json
+++ b/kubernetes/observability/dashboards/banking-app-health.json
@@ -107,12 +107,12 @@
     },
     {
       "type": "stat",
-      "title": "Memory",
-      "description": "JVM heap utilization (used / max) across all services",
+      "title": "Node Memory",
+      "description": "Busiest banking-app node's memory utilization (used / total) from node-exporter. Like Node CPU above, this is a property of the box, so the tile intentionally ignores the Service filter.",
       "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "sum(jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"}) / sum(jvm_memory_max_bytes{area=\"heap\", job=~\"$service\"})", "refId": "A"}
+        {"expr": "max(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {

--- a/kubernetes/observability/dashboards/banking-app-infra.json
+++ b/kubernetes/observability/dashboards/banking-app-infra.json
@@ -104,19 +104,18 @@
     },
     {
       "type": "timeseries",
-      "title": "CPU by Service",
-      "description": "Process CPU utilization per service (0-1 = one core)",
+      "title": "Container CPU — all workloads",
+      "description": "Container-level CPU usage from kubelet's cAdvisor (rate of CPU seconds consumed). Includes every banking workload regardless of language, not just Java services. 1.0 = one full core.",
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "process_cpu_usage{job=~\"$service\"}", "legendFormat": "{{job}}", "refId": "A"}
+        {"expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"banking-app\", container=~\".+-service|api-gateway\", container!=\"\"}[5m]))", "legendFormat": "{{container}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
           "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "showPoints": "never"},
           "unit": "percentunit",
           "min": 0,
-          "max": 1,
           "color": {"mode": "palette-classic"}
         }
       },
@@ -124,26 +123,19 @@
     },
     {
       "type": "timeseries",
-      "title": "Memory by Service — Heap Used vs Max",
-      "description": "JVM heap used (solid) vs max (dashed) per service",
+      "title": "Container Memory — all workloads",
+      "description": "Container working-set memory from kubelet's cAdvisor. Includes every banking workload regardless of language.",
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "sum by (job) (jvm_memory_used_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} used", "refId": "A"},
-        {"expr": "sum by (job) (jvm_memory_max_bytes{area=\"heap\", job=~\"$service\"})", "legendFormat": "{{job}} max", "refId": "B"}
+        {"expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"banking-app\", container=~\".+-service|api-gateway\", container!=\"\"})", "legendFormat": "{{container}}", "refId": "A"}
       ],
       "fieldConfig": {
         "defaults": {
           "custom": {"drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never"},
-          "unit": "bytes"
-        },
-        "overrides": [
-          {"matcher": {"id": "byRegexp", "options": ".* max"}, "properties": [
-            {"id": "custom.lineStyle", "value": {"fill": "dash", "dash": [10, 10]}},
-            {"id": "custom.fillOpacity", "value": 0},
-            {"id": "custom.lineWidth", "value": 1}
-          ]}
-        ]
+          "unit": "bytes",
+          "color": {"mode": "palette-classic"}
+        }
       },
       "options": {"tooltip": {"mode": "multi"}}
     },

--- a/kubernetes/observability/kustomization.yaml
+++ b/kubernetes/observability/kustomization.yaml
@@ -8,8 +8,10 @@ namespace: observability
 
 resources:
   - namespace.yaml
+  - prometheus-rbac.yaml
   - prometheus-deployment.yaml
   - prometheus-config.yaml
+  - node-exporter.yaml
   - otel-collector.yaml
   - jaeger-deployment.yaml
   - loki.yaml

--- a/kubernetes/observability/node-exporter.yaml
+++ b/kubernetes/observability/node-exporter.yaml
@@ -1,0 +1,87 @@
+---
+# Node-exporter exposes host-level metrics (memory, CPU, disk, network, load)
+# that aren't available from in-cluster cgroups or kubelet. Runs as a privileged
+# DaemonSet — one pod per node, host-PID + host-network so it can read the
+# real /proc and /sys filesystems.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: observability
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      containers:
+      - name: node-exporter
+        image: quay.io/prometheus/node-exporter:v1.8.2
+        args:
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+        ports:
+        - containerPort: 9100
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: proc
+          mountPath: /host/proc
+          readOnly: true
+        - name: sys
+          mountPath: /host/sys
+          readOnly: true
+        - name: root
+          mountPath: /host/root
+          mountPropagation: HostToContainer
+          readOnly: true
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: root
+        hostPath:
+          path: /
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  namespace: observability
+  labels:
+    app: node-exporter
+spec:
+  clusterIP: None
+  selector:
+    app: node-exporter
+  ports:
+  - port: 9100
+    targetPort: 9100
+    name: metrics

--- a/kubernetes/observability/prometheus-config.yaml
+++ b/kubernetes/observability/prometheus-config.yaml
@@ -61,3 +61,51 @@ data:
           - targets: ['banking-ai.banking-app:8080']
         metrics_path: '/actuator/prometheus'
         scrape_interval: 30s
+
+      # Node-level host metrics (memory, CPU, disk, network, load) from
+      # node-exporter — one pod per node, host-network so we can hit each
+      # one at its node IP:9100 via the headless Service endpoints.
+      - job_name: 'node-exporter'
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names: ['observability']
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: node-exporter;metrics
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: node
+        scrape_interval: 30s
+
+      # Per-container CPU + memory from kubelet's built-in cAdvisor endpoint.
+      # Discovers all nodes via the apiserver, proxies through it to reach
+      # /metrics/cadvisor on each kubelet (auth via SA token + apiserver CA).
+      - job_name: 'kubelet-cadvisor'
+        kubernetes_sd_configs:
+          - role: node
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        metric_relabel_configs:
+          # Drop ephemeral / mostly-noise series so we don't blow up storage.
+          - source_labels: [__name__]
+            regex: 'container_(blkio|fs|network)_.*'
+            action: drop
+          # Limit to banking-app + observability namespaces — we don't need
+          # control-plane container metrics on the demo dashboards.
+          - source_labels: [namespace]
+            regex: 'banking-app|observability'
+            action: keep
+        scrape_interval: 30s

--- a/kubernetes/observability/prometheus-deployment.yaml
+++ b/kubernetes/observability/prometheus-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccountName: prometheus
       containers:
         - name: prometheus
           image: prom/prometheus:v2.54.1

--- a/kubernetes/observability/prometheus-rbac.yaml
+++ b/kubernetes/observability/prometheus-rbac.yaml
@@ -1,0 +1,32 @@
+---
+# RBAC for Prometheus to discover nodes via the Kubernetes service-discovery
+# scrape config and proxy through the apiserver to /metrics/cadvisor.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/proxy", "nodes/metrics", "services", "endpoints", "pods"]
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: observability


### PR DESCRIPTION
## What

Two new scrape sources so dashboards have data regardless of which language a service is written in:

- **node-exporter** DaemonSet (1 pod per node) — standard host-level `node_*` metrics (memory, CPU, disk, network, load).
- **kubelet `/metrics/cadvisor`** via Kubernetes service-discovery, proxied through the apiserver — per-container `container_cpu_usage_seconds_total`, `container_memory_working_set_bytes`, etc. for every workload.

Plus the supporting RBAC: ServiceAccount + ClusterRole + ClusterRoleBinding for the Prometheus SA (nodes, nodes/proxy, pods, endpoints).

## Dashboards updated

- **Overview / Node Memory tile** — switched from JVM heap ratio to `max(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)`. Like Node CPU, intentionally unfiltered by `$service` because it's a property of the box.
- **Infrastructure / CPU + Memory by container** — swapped from `process_cpu_usage` and `jvm_memory_used_bytes` (Java-only) to cAdvisor's per-container metrics. Now shows every banking workload, including ai-service, fraud-service, notification-service, user-service.

JVM-deep panels (heap pools, GC, hikari pool, threads, classloader) stay Java-only on Infra — those are real JVM-runtime drills and don't translate.

## Live-verified

```
3 node-exporter targets up
3 kubelet-cadvisor targets up
count(node_memory_MemTotal_bytes) = 3
count(container_memory_working_set_bytes{namespace="banking-app"}) = 81
```
