### PR TITLE
responder mocks: keep goproxy sidecar so outbound is captured

### DIFF
--- a/kubernetes/overlays/speedscale/responders/README.md
+++ b/kubernetes/overlays/speedscale/responders/README.md
@@ -18,10 +18,23 @@ Coverage (≈20 third-party APIs across 6 services):
 
 ## Prerequisites (per Speedscale tenant)
 
-The `snapshotID`s and `testConfigID` below must exist in the target tenant. Push
-them with `speedctl push snapshot <id>` / `speedctl push test-config banking-mock-noproxy`.
-`banking-mock-noproxy` is a copy of `standard` with `responder.passthroughMode: false`
-(fail-closed). The Speedscale operator must be installed in the cluster.
+The `snapshotID`s and the `banking-mock-fail-closed` test config below must
+exist in the target tenant. Push them:
+
+```sh
+speedctl push snapshot <id>
+speedctl push test-config banking-mock-fail-closed.json
+```
+
+`banking-mock-fail-closed.json` (in this directory) is a fail-closed mock
+config: `responder.passthrough_mode: false` (404 on no-match, no real egress)
+plus `cluster.sidecar_tls_out: true` so the operator still injects the
+`speedscale-goproxy` sidecar. With the sidecar in path goproxy captures each
+outbound rrpair and surfaces it in the live tap. The previous
+`banking-mock-noproxy` config skipped the sidecar, which is why outbound was
+invisible to capture.
+
+The Speedscale operator must be installed in the cluster.
 
 ## Apply
 
@@ -29,9 +42,10 @@ them with `speedctl push snapshot <id>` / `speedctl push test-config banking-moc
 kubectl apply -f kubernetes/overlays/speedscale/responders/
 ```
 
-The operator provisions a responder pod + redis per service and injects `/etc/hosts`
-into each SUT, redirecting that service's external hosts to its responder. Remove
-with `kubectl delete -f .` to restore normal (real-egress) behavior.
+The operator provisions a responder pod + redis per service, injects the
+`speedscale-goproxy` sidecar into each SUT, and routes outbound to the
+responder. Remove with `kubectl delete -f .` to restore normal (real-egress)
+behavior.
 
 > Note: each `TrafficReplay` pins a `snapshotID`. These IDs are stable across the
 > `elastic` (staging) and `external` (dev) tenants where the snapshots were pushed.

--- a/kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
+++ b/kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
@@ -1,0 +1,27 @@
+{
+    "id": "banking-mock-fail-closed",
+    "generator": {
+        "stages": [
+            {
+                "virtualUsers": {
+                    "virtualUsers": "1",
+                    "requestDelay": {}
+                }
+            }
+        ]
+    },
+    "rules": [],
+    "version": 3,
+    "assertionGroups": [],
+    "responder": {
+        "numReplicas": 1,
+        "passthrough_mode": false
+    },
+    "cluster": {
+        "replayMode": "responder-only",
+        "logsCollected": false,
+        "sidecar_tls_out": true,
+        "cleanup": "inventory",
+        "logLevel": "info"
+    }
+}

--- a/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # accounts-scoped snapshot (Plaid + OXR + Moody), redacted, pushed to elastic tenant
   snapshotID: 25ef64bf-c07b-4adc-8ae3-33b2d6d5d6cf
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   # responder-only = fail-closed: 404 on no-match, NO passthrough to real dependency
   mode: responder-only
   workloadRef:

--- a/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: 7f7256a0-8876-4e3f-aea9-3fd681e0c36a
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: c3898583-282b-4b82-9bdb-72b7dd45d15c
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: c7bc4b14-40bd-46ae-88fd-f366b36de453
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: 68d2bc15-8931-4093-836e-a5ba3a5a5b5a
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment


### PR DESCRIPTION
# Problem

Banking workloads in staging-decoy have no `speedscale-goproxy` sidecar (every pod is 1/1). Live tap shows inbound but no outbound — because nothing is intercepting the outbound calls to Anthropic/OpenAI/Plaid/Stripe/etc.

Root cause: the 6 TR CRs reference `testConfigID: banking-mock-noproxy`, a custom test config that turned off `cluster.sidecar_tls_out`. With that flag off, the operator skips goproxy injection, the SUT calls the responder directly via injected `/etc/hosts`, and there is no proxy in path to capture the rrpair.

# Solution

Replace `banking-mock-noproxy` with `banking-mock-fail-closed.json`:

- `responder.passthrough_mode: false` — preserves fail-closed (404 on no-match, zero external egress).
- `cluster.sidecar_tls_out: true` — operator injects goproxy. Outbound rrpairs flow `SUT → goproxy → responder` and goproxy emits them to the firehose.

Shape matches the stock `mock-only` test config (`api-gateway/server/defaults/testconfigs/mock-only.json`) with `passthrough_mode` flipped to false. JSON is checked into `responders/` so the GitOps source-of-truth matches what the tenant has.

The 6 TR CRs are repointed; README updated.

## Deploy

Push the new test config to the elastic (and external) tenants before merging:

```sh
speedctl push test-config kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
```

Then merge; ArgoCD reconciles, operator re-rolls each banking deployment with goproxy, outbound becomes visible in the live tap.

## Checklist

- [x] Tests pass (no app code changed)
- [x] testConfig schema matches stock `mock-only` shape
- [x] README updated
- [x] No public API change