### PR TITLE
responder mocks: annotate TR CRs to actually force goproxy injection

### DIFF
--- a/kubernetes/overlays/speedscale/responders/README.md
+++ b/kubernetes/overlays/speedscale/responders/README.md
@@ -18,10 +18,23 @@ Coverage (≈20 third-party APIs across 6 services):
 
 ## Prerequisites (per Speedscale tenant)
 
-The `snapshotID`s and `testConfigID` below must exist in the target tenant. Push
-them with `speedctl push snapshot <id>` / `speedctl push test-config banking-mock-noproxy`.
-`banking-mock-noproxy` is a copy of `standard` with `responder.passthroughMode: false`
-(fail-closed). The Speedscale operator must be installed in the cluster.
+The `snapshotID`s and the `banking-mock-fail-closed` test config below must
+exist in the target tenant. Push them:
+
+```sh
+speedctl push snapshot <id>
+speedctl push test-config banking-mock-fail-closed.json
+```
+
+`banking-mock-fail-closed.json` (in this directory) is a fail-closed mock
+config: `responder.passthrough_mode: false` (404 on no-match, no real egress)
+plus `cluster.sidecar_tls_out: true` so the operator still injects the
+`speedscale-goproxy` sidecar. With the sidecar in path goproxy captures each
+outbound rrpair and surfaces it in the live tap. The previous
+`banking-mock-noproxy` config skipped the sidecar, which is why outbound was
+invisible to capture.
+
+The Speedscale operator must be installed in the cluster.
 
 ## Apply
 
@@ -29,9 +42,10 @@ them with `speedctl push snapshot <id>` / `speedctl push test-config banking-moc
 kubectl apply -f kubernetes/overlays/speedscale/responders/
 ```
 
-The operator provisions a responder pod + redis per service and injects `/etc/hosts`
-into each SUT, redirecting that service's external hosts to its responder. Remove
-with `kubectl delete -f .` to restore normal (real-egress) behavior.
+The operator provisions a responder pod + redis per service, injects the
+`speedscale-goproxy` sidecar into each SUT, and routes outbound to the
+responder. Remove with `kubectl delete -f .` to restore normal (real-egress)
+behavior.
 
 > Note: each `TrafficReplay` pins a `snapshotID`. These IDs are stable across the
 > `elastic` (staging) and `external` (dev) tenants where the snapshots were pushed.

--- a/kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
+++ b/kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
@@ -1,0 +1,27 @@
+{
+    "id": "banking-mock-fail-closed",
+    "generator": {
+        "stages": [
+            {
+                "virtualUsers": {
+                    "virtualUsers": "1",
+                    "requestDelay": {}
+                }
+            }
+        ]
+    },
+    "rules": [],
+    "version": 3,
+    "assertionGroups": [],
+    "responder": {
+        "numReplicas": 1,
+        "passthrough_mode": false
+    },
+    "cluster": {
+        "replayMode": "responder-only",
+        "logsCollected": false,
+        "sidecar_tls_out": true,
+        "cleanup": "inventory",
+        "logLevel": "info"
+    }
+}

--- a/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # accounts-scoped snapshot (Plaid + OXR + Moody), redacted, pushed to elastic tenant
   snapshotID: 25ef64bf-c07b-4adc-8ae3-33b2d6d5d6cf
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   # responder-only = fail-closed: 404 on no-match, NO passthrough to real dependency
   mode: responder-only
   workloadRef:

--- a/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
@@ -3,6 +3,9 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-accounts
   namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls-out: "true"
 spec:
   # accounts-scoped snapshot (Plaid + OXR + Moody), redacted, pushed to elastic tenant
   snapshotID: 25ef64bf-c07b-4adc-8ae3-33b2d6d5d6cf

--- a/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
@@ -3,6 +3,9 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-ai
   namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: 7f7256a0-8876-4e3f-aea9-3fd681e0c36a
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: 7f7256a0-8876-4e3f-aea9-3fd681e0c36a
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
@@ -3,6 +3,9 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-fraud
   namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: c3898583-282b-4b82-9bdb-72b7dd45d15c
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: c3898583-282b-4b82-9bdb-72b7dd45d15c
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -3,6 +3,9 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-notification
   namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: c7bc4b14-40bd-46ae-88fd-f366b36de453
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
@@ -3,6 +3,9 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-transactions
   namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: c7bc4b14-40bd-46ae-88fd-f366b36de453
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: banking-app
 spec:
   snapshotID: 68d2bc15-8931-4093-836e-a5ba3a5a5b5a
-  testConfigID: banking-mock-noproxy
+  testConfigID: banking-mock-fail-closed
   mode: responder-only
   workloadRef:
     kind: Deployment

--- a/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
@@ -3,6 +3,9 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-user
   namespace: banking-app
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: 68d2bc15-8931-4093-836e-a5ba3a5a5b5a
   testConfigID: banking-mock-fail-closed


### PR DESCRIPTION
# Problem

Follow-up to #208. After that PR merged and the new `banking-mock-fail-closed` testConfig was pushed to elastic, banking-ai pods stayed 1/1 — still no `speedscale-goproxy` container, still no outbound visibility in the live tap.

# Root cause

`operator/webhook/mutate_replay.go:142` has the canonical comment:

> we have incomplete support for full sidecar configuration via the cluster section of a replay testconfig. there are several ways we might see goproxy during a replay:
> 1. a replay is attempted for a workload that already has goproxy
> 2. a replay without outbound TLS implicitly adds goproxy
> 3. a replay CR contains annotations that add goproxy

`testConfig.cluster.sidecar_tls_out: true` (what #208 added) is path (2) inverted, so it doesn't trigger goproxy. We need path (3).

`operator/controllers/replay.go:355` copies any annotation on the TR CR with prefix `sidecar.speedscale.com/` as a **label** on the target workload (labels because Argo would fight annotation changes). Those labels drive goproxy injection at admission.

# Solution

Add to each of the 6 TR CRs:

```yaml
metadata:
  annotations:
    sidecar.speedscale.com/inject: "true"
    sidecar.speedscale.com/tls-out: "true"
```

After Argo sync, the replay reconciler propagates the labels to the banking-* deployments, the workload admission webhook injects goproxy, the responder still serves canned responses, and outbound rrpairs surface in the firehose.

`banking-mock-fail-closed` testConfig stays as-is — `sidecar_tls_out: true` there is still useful as the in-goproxy TLS-MITM hint.

## Checklist

- [x] Tests pass (no app code changed)
- [x] Annotations match the prefix the replay controller scans for
- [x] No public API change