### PR TITLE
speedscale-sidecar overlay: route banking via goproxy instead of nettap

### DIFF
--- a/kubernetes/overlays/speedscale-sidecar/kustomization.yaml
+++ b/kubernetes/overlays/speedscale-sidecar/kustomization.yaml
@@ -1,0 +1,111 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Sidecar-mode variant of the speedscale overlay.
+#
+# Inherits the full speedscale overlay (responder TRs, observability, metrics
+# services) and overrides the per-deployment annotation patches so each
+# banking workload runs with the speedscale-goproxy sidecar injected at
+# admission, instead of being routed to nettap (eBPF) by
+# capture.speedscale.com/enabled. eBPF and sidecar injection are mutually
+# exclusive in the operator (operator/webhook/admission.go), so flipping each
+# workload requires removing the capture.speedscale.com/* annotations and
+# adding the sidecar.speedscale.com/* ones.
+#
+# Used by staging-decoy, where we want goproxy in path so outbound rrpairs
+# show up in the live tap and replays can compare per-request bodies.
+# dev-decoy stays on the eBPF overlay.
+
+resources:
+  - ../speedscale
+
+patches:
+  - target:
+      kind: Deployment
+      name: banking-ai
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
+      name: banking-gateway
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1java-agent
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
+      name: banking-transactions
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1java-agent
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1ignore-ports
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
+      name: banking-accounts
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1java-agent
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1ignore-ports
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
+      name: banking-user
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1ignore-ports
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
+      name: banking-frontend
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"


### PR DESCRIPTION
# Problem

The \`kubernetes/overlays/speedscale\` overlay sets \`capture.speedscale.com/enabled: \"true\"\` on every banking-* Deployment. The operator's admission webhook reads this annotation as \`EBPFCaptureEnabled\` ([\`operator/webhook/admission.go:222\`](https://gitlab.com/speedscale/speedscale/-/blob/main/operator/webhook/admission.go#L222)) and routes the workload to the nettap DaemonSet. eBPF and goproxy injection are mutually exclusive, so every banking pod comes up 1/1 with no \`speedscale-goproxy\` sidecar and outbound HTTPS is invisible to the live tap.

# Solution

New \`kubernetes/overlays/speedscale-sidecar\` overlay that inherits the existing \`speedscale\` overlay (responder TRs, observability, metrics services, namespace label) and patches each banking-* Deployment to:
- drop \`capture.speedscale.com/enabled\`, \`/java-agent\`, \`/ignore-ports\`
- add \`sidecar.speedscale.com/inject: \"true\"\` + \`/tls-out: \"true\"\`

Verified \`kubectl kustomize\` builds clean; banking-ai Deployment comes out with only the sidecar annotations.

dev-decoy stays on the original eBPF overlay. staging-decoy will be repointed at the new path in a follow-up demo-infra MR.

## Checklist

- [x] Builds clean (\`kubectl kustomize kubernetes/overlays/speedscale-sidecar\`)
- [x] No app code changed
- [x] dev-decoy overlay path unchanged