### PR TITLE
speedscale-sidecar: cover banking-fraud and banking-notification too

### DIFF
--- a/kubernetes/overlays/speedscale-sidecar/kustomization.yaml
+++ b/kubernetes/overlays/speedscale-sidecar/kustomization.yaml
@@ -99,6 +99,32 @@ patches:
 
   - target:
       kind: Deployment
+      name: banking-fraud
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
+      name: banking-notification
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/capture.speedscale.com~1enabled
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1inject
+        value: "true"
+      - op: add
+        path: /metadata/annotations/sidecar.speedscale.com~1tls-out
+        value: "true"
+
+  - target:
+      kind: Deployment
       name: banking-frontend
     patch: |-
       - op: remove


### PR DESCRIPTION
# Problem

Follow-up to #211. The new \`speedscale-sidecar\` overlay missed two annotation files: \`fraud-service-annotations.yaml\` and \`notification-service-annotations.yaml\`. Result on staging-decoy: 5 of 7 banking pods came up 2/2 with goproxy as intended, but \`banking-fraud\` and \`banking-notification\` stayed 1/1 because they retained \`capture.speedscale.com/enabled: \"true\"\` (eBPF wins over sidecar).

# Solution

Add patches for both. \`kubectl kustomize\` verified — both Deployments now emit only the sidecar annotations.

## Checklist

- [x] kustomize builds clean
- [x] dev-decoy overlay path unchanged