### PR TITLE
Add replay namespace overlay

### DIFF
--- a/kubernetes/overlays/replay/kustomization.yaml
+++ b/kubernetes/overlays/replay/kustomization.yaml
@@ -1,0 +1,60 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: banking-app-replay
+
+resources:
+  - ../../base
+
+namespace: banking-replay
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: banking-app-replay
+      app.kubernetes.io/managed-by: kustomize
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: banking-sim
+        namespace: banking-app
+      $patch: delete
+  - patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: simulation-client-hpa
+        namespace: banking-app
+      $patch: delete
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: banking-sim-config
+        namespace: banking-app
+      $patch: delete
+  - patch: |-
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: banking-sim-secret
+        namespace: banking-app
+      $patch: delete
+  - target:
+      version: v1
+      kind: Namespace
+      name: banking-app
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: banking-replay
+      - op: replace
+        path: /metadata/labels/name
+        value: banking-replay
+      - op: replace
+        path: /metadata/labels/app.kubernetes.io~1name
+        value: banking-app-replay

--- a/thoughts/proofs.md
+++ b/thoughts/proofs.md
@@ -21,3 +21,9 @@
 - **Evidence**: `kubectl kustomize kubernetes/overlays/speedscale-sidecar` rendered 4,964 lines
 - **Status**: PROVEN
 - **Date**: 2026-06-18
+
+## The replay overlay renders an isolated banking-replay app
+- **Level**: Integration
+- **Evidence**: `thoughts/scripts/verify-replay-overlay.sh` PASS
+- **Status**: PROVEN
+- **Date**: 2026-06-18

--- a/thoughts/scripts/verify-replay-overlay.sh
+++ b/thoughts/scripts/verify-replay-overlay.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Proves: kubernetes/overlays/replay renders an isolated banking-replay app without organic sim traffic.
+# Created: 2026-06-18 after adding the replay namespace overlay.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+kubectl kustomize "$ROOT/kubernetes/overlays/replay" > "$out"
+
+grep -q '^  name: banking-replay$' "$out" || {
+  echo "FAIL: banking-replay namespace missing"
+  exit 1
+}
+
+if grep -Eq 'namespace: banking-app|name: banking-sim|simulation-client-hpa|banking-sim-config|banking-sim-secret' "$out"; then
+  echo "FAIL: replay overlay still contains live namespace or simulation resources"
+  exit 1
+fi
+
+grep -q '^  name: banking-ai$' "$out" || {
+  echo "FAIL: banking-ai deployment/service missing"
+  exit 1
+}
+
+echo "PASS: replay overlay renders in banking-replay without simulation traffic"


### PR DESCRIPTION
## Summary
- add `kubernetes/overlays/replay` to deploy the demo app into `banking-replay`
- remove organic simulation resources from the replay target namespace
- add proof notes and a local verification script for the replay overlay

## Why
Quality replays need an isolated app target instead of competing with live demo traffic in `banking-app`.

## Validation
- `kubectl kustomize kubernetes/overlays/replay`
- `kubectl kustomize kubernetes/overlays/speedscale-sidecar`
- `thoughts/scripts/verify-replay-overlay.sh`