### PR TITLE
Add Kafka SASL demo overlay

### DIFF
--- a/backend/notification-service/cmd/server/main.go
+++ b/backend/notification-service/cmd/server/main.go
@@ -19,6 +19,11 @@ func main() {
 	brokers := strings.Split(envOrDefault("KAFKA_BROKERS", "banking-kafka:9092"), ",")
 	topic := envOrDefault("KAFKA_TOPIC", "transaction-events")
 	mongoURI := envOrDefault("MONGO_URI", "mongodb://banking-mongodb:27017")
+	kafkaAuth := consumer.AuthConfig{
+		Mechanism: os.Getenv("KAFKA_SASL_MECHANISM"),
+		Username:  os.Getenv("KAFKA_SASL_USERNAME"),
+		Password:  os.Getenv("KAFKA_SASL_PASSWORD"),
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
@@ -31,7 +36,10 @@ func main() {
 		mongoStore = ms
 	}
 
-	c := consumer.New(brokers, topic, "notification-service", mongoStore)
+	c, err := consumer.NewWithAuth(brokers, topic, "notification-service", mongoStore, kafkaAuth)
+	if err != nil {
+		log.Fatalf("Kafka configuration error: %v", err)
+	}
 	defer c.Close()
 
 	go c.Run(ctx)

--- a/backend/notification-service/internal/consumer/kafka.go
+++ b/backend/notification-service/internal/consumer/kafka.go
@@ -3,11 +3,15 @@ package consumer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
 	kafka "github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl"
+	"github.com/segmentio/kafka-go/sasl/plain"
 
 	"github.com/speedscale/microsvc/notification-service/internal/metrics"
 	"github.com/speedscale/microsvc/notification-service/internal/notify"
@@ -93,20 +97,63 @@ type Consumer struct {
 	notifier *notify.Notifier
 }
 
+type AuthConfig struct {
+	Mechanism string
+	Username  string
+	Password  string
+}
+
 func New(brokers []string, topic, groupID string, store Store) *Consumer {
-	r := kafka.NewReader(kafka.ReaderConfig{
+	c, err := NewWithAuth(brokers, topic, groupID, store, AuthConfig{})
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func NewWithAuth(brokers []string, topic, groupID string, store Store, auth AuthConfig) (*Consumer, error) {
+	cfg := kafka.ReaderConfig{
 		Brokers:        brokers,
 		Topic:          topic,
 		GroupID:        groupID,
 		MinBytes:       1,
 		MaxBytes:       10e6,
 		CommitInterval: time.Second,
-	})
+	}
+
+	if auth.Mechanism != "" {
+		mechanism, err := saslMechanism(auth)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Dialer = &kafka.Dialer{
+			Timeout:       10 * time.Second,
+			DualStack:     true,
+			SASLMechanism: mechanism,
+		}
+	}
+
+	r := kafka.NewReader(cfg)
 	return &Consumer{
 		reader:   r,
 		Buffer:   &RingBuffer{},
 		store:    store,
 		notifier: notify.NewNotifier(),
+	}, nil
+}
+
+func saslMechanism(auth AuthConfig) (sasl.Mechanism, error) {
+	switch strings.ToUpper(auth.Mechanism) {
+	case "PLAIN":
+		if auth.Username == "" || auth.Password == "" {
+			return nil, fmt.Errorf("KAFKA_SASL_USERNAME and KAFKA_SASL_PASSWORD are required for PLAIN")
+		}
+		return plain.Mechanism{
+			Username: auth.Username,
+			Password: auth.Password,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported Kafka SASL mechanism %q", auth.Mechanism)
 	}
 }
 

--- a/backend/notification-service/internal/consumer/kafka_test.go
+++ b/backend/notification-service/internal/consumer/kafka_test.go
@@ -1,0 +1,55 @@
+package consumer
+
+import "testing"
+
+func TestNewWithAuthPlainConfiguresDialer(t *testing.T) {
+	c, err := NewWithAuth(
+		[]string{"banking-kafka:9092"},
+		"transaction-events",
+		"notification-service",
+		nil,
+		AuthConfig{
+			Mechanism: "PLAIN",
+			Username:  "banking",
+			Password:  "secret",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewWithAuth returned error: %v", err)
+	}
+	defer c.Close()
+
+	if c.reader.Config().Dialer == nil {
+		t.Fatal("expected SASL dialer")
+	}
+}
+
+func TestNewWithAuthRequiresPlainCredentials(t *testing.T) {
+	_, err := NewWithAuth(
+		[]string{"banking-kafka:9092"},
+		"transaction-events",
+		"notification-service",
+		nil,
+		AuthConfig{Mechanism: "PLAIN"},
+	)
+	if err == nil {
+		t.Fatal("expected missing credentials error")
+	}
+}
+
+func TestNewWithAuthRejectsUnsupportedMechanism(t *testing.T) {
+	_, err := NewWithAuth(
+		[]string{"banking-kafka:9092"},
+		"transaction-events",
+		"notification-service",
+		nil,
+		AuthConfig{
+			Mechanism: "SCRAM-SHA-256",
+			Username:  "banking",
+			Password:  "secret",
+		},
+	)
+	if err == nil {
+		t.Fatal("expected unsupported mechanism error")
+	}
+}

--- a/kubernetes/overlays/kafka-sasl/README.md
+++ b/kubernetes/overlays/kafka-sasl/README.md
@@ -1,0 +1,13 @@
+# Kafka SASL overlay
+
+This overlay runs the banking app with Kafka client authentication enabled.
+It keeps the base app unchanged and switches only the Kafka listener plus the
+transactions and notification clients.
+
+```bash
+kubectl apply -k kubernetes/overlays/kafka-sasl
+```
+
+The demo uses `SASL_PLAINTEXT` with the `PLAIN` mechanism and non-production
+credentials in `banking-kafka-sasl`. Use it for capture and replay testing of
+authenticated Kafka traffic, not for production.

--- a/kubernetes/overlays/kafka-sasl/kafka-sasl-deployment.yaml
+++ b/kubernetes/overlays/kafka-sasl/kafka-sasl-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: banking-kafka
+  namespace: banking-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: kafka
+        env:
+        - name: ALLOW_PLAINTEXT_LISTENER
+          value: "yes"
+        - name: KAFKA_CFG_LISTENERS
+          value: "SASL_PLAINTEXT://:9092,CONTROLLER://:9093"
+        - name: KAFKA_CFG_ADVERTISED_LISTENERS
+          value: "SASL_PLAINTEXT://banking-kafka:9092"
+        - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
+          value: "CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT"
+        - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
+          value: "SASL_PLAINTEXT"
+        - name: KAFKA_CFG_SASL_ENABLED_MECHANISMS
+          value: "PLAIN"
+        - name: KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL
+          value: "PLAIN"
+        - name: KAFKA_CLIENT_USERS
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: users
+        - name: KAFKA_CLIENT_PASSWORDS
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: passwords
+        - name: KAFKA_INTER_BROKER_USER
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: username
+        - name: KAFKA_INTER_BROKER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: password

--- a/kubernetes/overlays/kafka-sasl/kafka-sasl-secret.yaml
+++ b/kubernetes/overlays/kafka-sasl/kafka-sasl-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: banking-kafka-sasl
+  namespace: banking-app
+type: Opaque
+stringData:
+  username: banking
+  password: banking-secret
+  users: banking
+  passwords: banking-secret

--- a/kubernetes/overlays/kafka-sasl/kustomization.yaml
+++ b/kubernetes/overlays/kafka-sasl/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: banking-app
+
+resources:
+- ../../base
+- kafka-sasl-secret.yaml
+
+patches:
+- path: kafka-sasl-deployment.yaml
+- path: transactions-service-kafka-sasl.yaml
+- path: notification-service-kafka-sasl.yaml

--- a/kubernetes/overlays/kafka-sasl/notification-service-kafka-sasl.yaml
+++ b/kubernetes/overlays/kafka-sasl/notification-service-kafka-sasl.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: banking-notification
+  namespace: banking-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: notification-service
+        env:
+        - name: KAFKA_SASL_MECHANISM
+          value: "PLAIN"
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: username
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: password

--- a/kubernetes/overlays/kafka-sasl/transactions-service-kafka-sasl.yaml
+++ b/kubernetes/overlays/kafka-sasl/transactions-service-kafka-sasl.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: banking-transactions
+  namespace: banking-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: transactions-service
+        env:
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: username
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banking-kafka-sasl
+              key: password
+        - name: SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL
+          value: "SASL_PLAINTEXT"
+        - name: SPRING_KAFKA_PROPERTIES_SASL_MECHANISM
+          value: "PLAIN"
+        - name: SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG
+          value: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$(KAFKA_SASL_USERNAME)" password="$(KAFKA_SASL_PASSWORD)";'


### PR DESCRIPTION
## Title

Add Kafka SASL demo overlay

## Description

Adds a dedicated `kafka-sasl` Kubernetes overlay for the banking app so the existing Kafka transaction flow can run with `SASL_PLAINTEXT` and the `PLAIN` mechanism while leaving the base plaintext deployment unchanged.

The overlay configures the in-cluster Kafka broker with demo SASL credentials, wires the Java `transactions-service` producer through Spring Kafka properties, and wires the Go `notification-service` consumer through new optional SASL environment variables. The notification consumer keeps the existing plaintext path when SASL env vars are absent.

## Checklist

- [x] Added isolated `kubernetes/overlays/kafka-sasl` deploy target
- [x] Added optional SASL auth support for `notification-service`
- [x] Added focused tests for Kafka auth config
- [x] Ran `go test ./...` in `backend/notification-service`
- [x] Rendered `kubectl kustomize kubernetes/overlays/kafka-sasl`
- [x] Ran client-side manifest dry run
- [x] Smoke-tested Bitnami Kafka startup and SASL client handshake locally
