### PR TITLE
Disable DB startup validation in replay

### DIFF
--- a/kubernetes/overlays/replay/kustomization.yaml
+++ b/kubernetes/overlays/replay/kustomization.yaml
@@ -58,3 +58,30 @@ patches:
       - op: replace
         path: /metadata/labels/app.kubernetes.io~1name
         value: banking-app-replay
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: banking-user-config
+        namespace: banking-app
+      data:
+        SPRING_FLYWAY_ENABLED: "false"
+        SPRING_JPA_HIBERNATE_DDL_AUTO: "none"
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: banking-accounts-config
+        namespace: banking-app
+      data:
+        SPRING_FLYWAY_ENABLED: "false"
+        SPRING_JPA_HIBERNATE_DDL_AUTO: "none"
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: banking-transactions-config
+        namespace: banking-app
+      data:
+        SPRING_FLYWAY_ENABLED: "false"
+        SPRING_JPA_HIBERNATE_DDL_AUTO: "none"


### PR DESCRIPTION
## Summary
- disable Flyway and Hibernate schema validation in the replay overlay for the Postgres-backed banking services
- keep the change scoped to the replay namespace so normal app deployments still validate their database schema

## Validation
- kubectl kustomize kubernetes/overlays/replay
- rendered manifest includes SPRING_FLYWAY_ENABLED=false and SPRING_JPA_HIBERNATE_DDL_AUTO=none for user, accounts, and transactions
- git diff --check