### PR TITLE
Add local microsvc demo story loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ application-local.properties
 
 # proxymock (results and logs — recordings used by CI stay tracked)
 **/proxymock/results/
+**/proxymock/live-*/
+**/proxymock/imported-s3-*/
+**/proxymock/local-transfer-*/
 **/*proxymock*.log
 **/*.log
 

--- a/backend/accounts-service/Dockerfile
+++ b/backend/accounts-service/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn clean package -DskipTests
 RUN java -Djarmode=layertools -jar target/accounts-service-*.jar extract
 
 # Runtime image - use Amazon Corretto Alpine for Colima compatibility
-FROM --platform=$TARGETPLATFORM amazoncorretto:17-alpine
+FROM amazoncorretto:17-alpine
 
 WORKDIR /app
 

--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn clean package -DskipTests
 RUN java -Djarmode=layertools -jar target/api-gateway-*.jar extract
 
 # Runtime image - use Amazon Corretto Alpine for Colima compatibility
-FROM --platform=$TARGETPLATFORM amazoncorretto:17-alpine
+FROM amazoncorretto:17-alpine
 
 WORKDIR /app
 

--- a/backend/transactions-service/Dockerfile
+++ b/backend/transactions-service/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn clean package -DskipTests
 RUN java -Djarmode=layertools -jar target/transactions-service-*.jar extract
 
 # Runtime image - use Amazon Corretto Alpine for Colima compatibility
-FROM --platform=$TARGETPLATFORM amazoncorretto:17-alpine
+FROM amazoncorretto:17-alpine
 
 WORKDIR /app
 

--- a/docs/demo-story-local-loop.md
+++ b/docs/demo-story-local-loop.md
@@ -1,0 +1,77 @@
+# Demo Story Local Loop
+
+Use this loop to test the observability demo locally before waiting on staging.
+
+## First Run
+
+```bash
+scripts/demo-story-loop.sh start-minikube
+scripts/demo-story-loop.sh build
+scripts/demo-story-loop.sh deploy
+scripts/demo-story-loop.sh api-check
+scripts/demo-story-loop.sh browser-check
+scripts/demo-story-loop.sh traffic-check
+scripts/demo-story-loop.sh web-check
+scripts/demo-story-loop.sh replay-check
+scripts/demo-story-loop.sh transfer-replay-check
+scripts/demo-story-loop.sh fresh-capture-check
+```
+
+The first `build` is slow because it warms Docker, Maven, npm, and Python caches inside the `speedscale-demo-mini` minikube profile.
+
+## Repair Loop
+
+After the first run, rebuild only the services you changed:
+
+```bash
+scripts/demo-story-loop.sh build frontend
+scripts/demo-story-loop.sh deploy frontend
+scripts/demo-story-loop.sh api-check
+scripts/demo-story-loop.sh browser-check
+```
+
+For a frontend-only bug, this is usually enough:
+
+```bash
+scripts/demo-story-loop.sh once frontend
+```
+
+To keep cycling a set of workloads until one fails:
+
+```bash
+scripts/demo-story-loop.sh loop frontend api-gateway transactions-service
+```
+
+## What The Checks Prove
+
+`api-check` logs in as `harper.clark.001`, verifies funded checking and savings accounts, and confirms the transfer-review request returns the expected compliance-review response.
+
+`browser-check` opens the local frontend through a temporary port-forward, verifies the homepage shows Harper Clark, logs in with the prefilled demo user, starts the transfer review, and fails if the transfer page crashes.
+
+`traffic-check` verifies that a proxymock capture directory contains the demo evidence: frontend, gateway, accounts, transactions, user, fraud gRPC, notification, Postgres, Redis, Kafka, and external API traffic. Pass a capture directory explicitly or set `PROXYMOCK_CAPTURE_DIR`; otherwise the newest `live-*` or `imported-s3-*` capture under `backend/ai-service/proxymock` is used.
+
+`web-check` starts proxymock web against the local proxymock workspace, selects the live banking run, and verifies that Pull, Replay, the live run row count, and banking traffic rows are visible.
+
+`replay-check` extracts captured `banking-gateway` login requests, port-forwards the local gateway, and runs `proxymock replay` with failure and result-match checks.
+
+`transfer-replay-check` records the transfer-review request through proxymock's inbound proxy, confirms the live app returns the expected `400`, then replays that captured request against the local gateway and fails if replay does not include a successful `/api/transactions/transfer` result.
+
+`fresh-capture-check` writes a new `local-transfer-*` run under the local proxymock workspace, replays it against the gateway, then starts proxymock web and verifies that exact fresh run is visible with login, accounts, and transfer traffic rows.
+
+`deploy [service...]` restarts the selected workloads after applying the overlay. This matters because local images reuse the `:local` tag, so an unchanged Kubernetes manifest is not enough to prove a rebuilt container is running.
+
+After the cluster is healthy, `deploy [service...]` waits only for the selected workload plus the seed job. A fresh or unhealthy cluster still gets a full rollout wait.
+
+`loop [service...]` runs one workload at a time and stops on the first failing build, rollout, API check, or browser check. Set `LOOP_DELAY_SECONDS` if you want a pause between iterations.
+
+The minikube loop overlay uses a short local pod termination grace period so repeated restarts do not wait on the production defaults.
+
+## Defaults
+
+- config: `~/spd-workspace/speedstack/instances/microsvc-demo-mini/minikube.env`
+- minikube profile: `speedscale-demo-mini`
+- Kubernetes context: `speedscale-demo-mini`
+- namespace: `banking-app`
+- overlay: `kubernetes/overlays/minikube-loop`
+- manual frontend port-forward: `http://127.0.0.1:3000`
+- browser-check port: random local port, or `BROWSER_FRONTEND_PORT` if set

--- a/frontend/src/app/accounts/[id]/transfer/page.tsx
+++ b/frontend/src/app/accounts/[id]/transfer/page.tsx
@@ -125,10 +125,10 @@ const TransferPage: React.FC = () => {
     }
   };
 
-  const formatCurrency = (amount: number, currency: string) => {
+  const formatCurrency = (amount: number, currency?: string) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: currency,
+      currency: currency || 'USD',
     }).format(amount);
   };
 

--- a/kubernetes/base/jobs/seed-user-pool.yaml
+++ b/kubernetes/base/jobs/seed-user-pool.yaml
@@ -59,14 +59,32 @@ spec:
                   }
               }
 
-              top_up_account() {
+              withdraw_from() {
                 account_id="$1"
                 amount="$2"
                 description="$3"
+                wget -q -O- --post-data="{\"amount\":$amount,\"accountId\":$account_id,\"description\":\"$description\"}" \
+                  --header="Authorization: Bearer $TOKEN" \
+                  --header='Content-Type: application/json' \
+                  "$BASE_URL/api/transactions/withdraw" 2>&1 || {
+                    echo "Withdrawal failed for account $account_id amount $amount"
+                    exit 1
+                  }
+              }
+
+              adjust_account() {
+                account_id="$1"
+                amount="$2"
+                direction="$3"
+                description="$4"
                 remaining="$amount"
                 while awk -v amount="$remaining" 'BEGIN { exit !(amount > 0.009) }'; do
                   chunk=$(awk -v amount="$remaining" 'BEGIN { if (amount > 900) printf "900.00"; else printf "%.2f", amount }')
-                  deposit_to "$account_id" "$chunk" "$description"
+                  if [ "$direction" = "deposit" ]; then
+                    deposit_to "$account_id" "$chunk" "$description"
+                  else
+                    withdraw_from "$account_id" "$chunk" "$description"
+                  fi
                   remaining=$(awk -v amount="$remaining" -v chunk="$chunk" 'BEGIN { printf "%.2f", amount - chunk }')
                   sleep 1
                 done
@@ -97,12 +115,16 @@ spec:
                   exit 1
                 fi
 
-                top_up=$(awk -v target="$target_balance" -v current="$balance" 'BEGIN { if (current < target) printf "%.2f", target - current; else printf "0" }')
-                if awk -v amount="$top_up" 'BEGIN { exit !(amount > 0.009) }'; then
-                  echo "Topping up $type account $account_id by $top_up..."
-                  top_up_account "$account_id" "$top_up" "$type account setup"
+                adjustment=$(awk -v target="$target_balance" -v current="$balance" 'BEGIN { printf "%.2f", target - current }')
+                if awk -v amount="$adjustment" 'BEGIN { exit !(amount > 0.009) }'; then
+                  echo "Topping up $type account $account_id by $adjustment..."
+                  adjust_account "$account_id" "$adjustment" deposit "$type account setup"
+                elif awk -v amount="$adjustment" 'BEGIN { exit !(amount < -0.009) }'; then
+                  withdrawal=$(awk -v amount="$adjustment" 'BEGIN { printf "%.2f", -amount }')
+                  echo "Reducing $type account $account_id by $withdrawal..."
+                  adjust_account "$account_id" "$withdrawal" withdraw "$type account reset"
                 else
-                  echo "$type account $account_id already funded at $balance."
+                  echo "$type account $account_id already at $balance."
                 fi
               }
 

--- a/kubernetes/overlays/minikube-loop/kustomization.yaml
+++ b/kubernetes/overlays/minikube-loop/kustomization.yaml
@@ -1,0 +1,96 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../local
+
+images:
+- name: ghcr.io/speedscale/microsvc/accounts-service
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/ai-service
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/api-gateway
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/fraud-service
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/frontend
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/notification-service
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/simulation-client
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/transactions-service
+  newTag: local
+- name: ghcr.io/speedscale/microsvc/user-service
+  newTag: local
+
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+    - op: add
+      path: /spec/template/spec/terminationGracePeriodSeconds
+      value: 5
+- target:
+    kind: Deployment
+    name: banking-accounts
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-ai
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-gateway
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-fraud
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-frontend
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-notification
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-sim
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-transactions
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+- target:
+    kind: Deployment
+    name: banking-user
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent

--- a/scripts/demo-story-browser-check.mjs
+++ b/scripts/demo-story-browser-check.mjs
@@ -1,0 +1,88 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(new URL('../frontend/package.json', import.meta.url));
+const { chromium } = require('@playwright/test');
+
+const baseURL = process.env.BASE_URL || 'http://127.0.0.1:3000';
+const headless = process.env.HEADLESS !== 'false';
+const maxAttempts = Number(process.env.BROWSER_CHECK_ATTEMPTS || 20);
+const retryDelayMs = Number(process.env.BROWSER_CHECK_RETRY_DELAY_MS || 1000);
+const errors = [];
+
+const browser = await chromium.launch({ headless });
+const page = await browser.newPage();
+
+page.on('console', (msg) => {
+  if (msg.type() === 'error') errors.push(msg.text());
+});
+page.on('pageerror', (error) => {
+  errors.push(error.stack || error.message);
+});
+
+async function fail(message) {
+  await browser.close();
+  throw new Error(message);
+}
+
+async function waitForFormValue(value) {
+  await page.waitForFunction((expected) => {
+    return Array.from(document.querySelectorAll('input, textarea'))
+      .some((element) => element.value === expected);
+  }, value, { timeout: 15000 });
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function gotoWithRetry(url) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await page.goto(url, { waitUntil: 'domcontentloaded' });
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw lastError || new Error(`failed to load ${url}`);
+}
+
+await gotoWithRetry(baseURL);
+await page.getByText('Harper Clark').waitFor({ timeout: 15000 });
+await page.getByText('harper.clark.001').waitFor({ timeout: 15000 });
+
+await gotoWithRetry(`${baseURL}/login`);
+await page.getByPlaceholder('Enter your username or email').waitFor({ timeout: 15000 });
+
+const username = await page.getByPlaceholder('Enter your username or email').inputValue();
+const password = await page.getByPlaceholder('Enter your password').inputValue();
+if (username !== 'harper.clark.001') await fail(`login username was ${username}`);
+if (password !== 'SimUser123!') await fail('login password was not prefilled');
+
+await page.getByRole('button', { name: 'Sign in' }).click();
+await page.waitForURL('**/dashboard', { timeout: 15000 });
+await page.getByText('Checking and savings accounts are ready.').waitFor({ timeout: 15000 });
+
+await page.getByRole('button', { name: 'Start Transfer Review' }).click();
+await page.waitForLoadState('domcontentloaded');
+await page.waitForTimeout(1000);
+
+if ((await page.getByText('Application error: a client-side exception has occurred').count()) > 0) {
+  await fail(`transfer page crashed: ${errors.join('\n')}`);
+}
+
+await page.getByRole('heading', { name: 'Transfer Money' }).waitFor({ timeout: 15000 });
+await waitForFormValue('125.00');
+await waitForFormValue('Emergency fund transfer');
+
+console.log(JSON.stringify({
+  ok: true,
+  baseURL,
+  path: new URL(page.url()).pathname + new URL(page.url()).search,
+}, null, 2));
+
+await browser.close();

--- a/scripts/demo-story-fresh-capture-check.sh
+++ b/scripts/demo-story-fresh-capture-check.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+run_name="${FRESH_CAPTURE_RUN:-local-transfer-$(date -u +%Y-%m-%d_%H-%M-%S)}"
+capture_dir="${FRESH_CAPTURE_DIR:-$repo_root/backend/ai-service/proxymock/$run_name}"
+replay_out="${FRESH_CAPTURE_REPLAY_OUT:-$(mktemp -d "/tmp/microsvc-fresh-replay.XXXXXX")}"
+
+rm -rf "$capture_dir"
+mkdir -p "$capture_dir"
+
+TRANSFER_REPLAY_CAPTURE_DIR="$capture_dir" \
+TRANSFER_REPLAY_OUT_DIR="$replay_out" \
+"$repo_root/scripts/demo-story-transfer-replay-check.sh"
+
+PROXYMOCK_WEB_RUN="$run_name" \
+PROXYMOCK_WEB_MIN_ROWS="${FRESH_CAPTURE_MIN_ROWS:-3}" \
+PROXYMOCK_WEB_REQUIRED_TEXT="${FRESH_CAPTURE_REQUIRED_TEXT:-$run_name,Pull,Replay,banking-gateway,/api/users/login,/api/accounts,/api/transactions/transfer}" \
+"$repo_root/scripts/demo-story-web-check.sh"
+
+echo "fresh capture run: $run_name"
+echo "fresh capture dir: $capture_dir"

--- a/scripts/demo-story-loop.sh
+++ b/scripts/demo-story-loop.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+config_file="${DEMO_LOOP_CONFIG:-$HOME/spd-workspace/speedstack/instances/microsvc-demo-mini/minikube.env}"
+if [ -f "$config_file" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$config_file"
+  set +a
+fi
+
+profile="${MINIKUBE_PROFILE:-speedscale-demo-mini}"
+context="${KUBE_CONTEXT:-$profile}"
+namespace="${NAMESPACE:-banking-app}"
+registry="${REGISTRY:-ghcr.io/speedscale/microsvc}"
+tag="${IMAGE_TAG:-local}"
+frontend_port="${FRONTEND_PORT:-3000}"
+overlay="${KUSTOMIZE_OVERLAY:-$repo_root/kubernetes/overlays/minikube-loop}"
+
+services=(
+  "accounts-service:backend/accounts-service"
+  "ai-service:backend/ai-service"
+  "api-gateway:backend/api-gateway"
+  "fraud-service:backend/fraud-service"
+  "frontend:frontend"
+  "notification-service:backend/notification-service"
+  "simulation-client:simulation-client"
+  "transactions-service:backend/transactions-service"
+  "user-service:backend/user-service"
+)
+
+deployments=(
+  banking-postgres
+  redis
+  mongodb
+  banking-kafka
+  banking-user
+  banking-accounts
+  banking-transactions
+  banking-fraud
+  banking-notification
+  banking-ai
+  banking-gateway
+  banking-frontend
+  banking-sim
+)
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/demo-story-loop.sh <command> [service...]
+
+Commands:
+  start-minikube       Start minikube if it is stopped
+  build [service...]   Build all images, or only named services, into minikube
+  deploy [service...]  Apply the local overlay, restart services, and wait for rollouts
+  api-check            Verify Harper Clark and the transfer review path in-cluster
+  browser-check        Port-forward frontend and run the browser story check
+  traffic-check [dir]  Verify proxymock capture evidence for the demo story
+  web-check            Verify proxymock web can display the live capture
+  replay-check [dir]   Replay captured gateway login traffic against the local gateway
+  transfer-replay-check Record and replay the transfer-review request locally
+  fresh-capture-check  Record fresh transfer traffic, replay it, and view it in web
+  once [service...]    start-minikube, build, deploy, api-check, browser-check
+  loop [service...]    Repeat one-service repair loops until stopped or failed
+  port-forward         Forward local :3000 to the frontend service
+  status               Show local pods and services
+  clean                Delete the local banking app namespace resources
+
+Examples:
+  scripts/demo-story-loop.sh once frontend
+  scripts/demo-story-loop.sh loop frontend api-gateway transactions-service
+  scripts/demo-story-loop.sh build frontend api-gateway
+  scripts/demo-story-loop.sh deploy
+  scripts/demo-story-loop.sh browser-check
+  scripts/demo-story-loop.sh traffic-check
+  scripts/demo-story-loop.sh web-check
+  scripts/demo-story-loop.sh replay-check
+  scripts/demo-story-loop.sh transfer-replay-check
+  scripts/demo-story-loop.sh fresh-capture-check
+
+Defaults:
+  DEMO_LOOP_CONFIG=$HOME/spd-workspace/speedstack/instances/microsvc-demo-mini/minikube.env
+  MINIKUBE_PROFILE=speedscale-demo-mini
+  KUBE_CONTEXT=$MINIKUBE_PROFILE
+  NAMESPACE=banking-app
+  KUSTOMIZE_OVERLAY=kubernetes/overlays/minikube-loop
+USAGE
+}
+
+run_kubectl() {
+  kubectl --context "$context" "$@"
+}
+
+start_minikube() {
+  if minikube -p "$profile" status >/dev/null 2>&1; then
+    return
+  fi
+
+  minikube start -p "$profile" --cpus="${MINIKUBE_CPUS:-4}" --memory="${MINIKUBE_MEMORY:-6144}"
+}
+
+selected_services() {
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "${services[@]}"
+    return
+  fi
+
+  local wanted service name found
+  for wanted in "$@"; do
+    found=false
+    for service in "${services[@]}"; do
+      name="${service%%:*}"
+      if [ "$wanted" = "$name" ]; then
+        printf '%s\n' "$service"
+        found=true
+      fi
+    done
+    if [ "$found" = false ]; then
+      echo "unknown service: $wanted" >&2
+      exit 2
+    fi
+  done
+}
+
+build_images() {
+  start_minikube
+  eval "$(minikube -p "$profile" docker-env)"
+
+  local service name context_dir
+  while IFS= read -r service; do
+    name="${service%%:*}"
+    context_dir="${service#*:}"
+    echo "Building $registry/$name:$tag"
+    docker build -t "$registry/$name:$tag" "$repo_root/$context_dir"
+  done < <(selected_services "$@")
+}
+
+deploy_local() {
+  start_minikube
+  local wait_all
+  wait_all=false
+  if [ "$#" -eq 0 ] || ! cluster_ready; then
+    wait_all=true
+  fi
+
+  run_kubectl delete job seed-user-pool -n "$namespace" --ignore-not-found
+  run_kubectl apply -k "$overlay"
+  restart_deployments "$@"
+  if [ "$wait_all" = true ]; then
+    wait_rollouts
+  else
+    wait_rollouts "$@"
+  fi
+}
+
+deployment_for_service() {
+  case "$1" in
+    accounts-service) echo banking-accounts ;;
+    ai-service) echo banking-ai ;;
+    api-gateway) echo banking-gateway ;;
+    fraud-service) echo banking-fraud ;;
+    frontend) echo banking-frontend ;;
+    notification-service) echo banking-notification ;;
+    simulation-client) echo banking-sim ;;
+    transactions-service) echo banking-transactions ;;
+    user-service) echo banking-user ;;
+    *)
+      echo "unknown service: $1" >&2
+      exit 2
+      ;;
+  esac
+}
+
+restart_deployments() {
+  local service name deployment
+  while IFS= read -r service; do
+    name="${service%%:*}"
+    deployment="$(deployment_for_service "$name")"
+    run_kubectl rollout restart "deployment/$deployment" -n "$namespace"
+  done < <(selected_services "$@")
+}
+
+cluster_ready() {
+  local deployment desired available
+  for deployment in "${deployments[@]}"; do
+    desired="$(run_kubectl get "deployment/$deployment" -n "$namespace" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)"
+    available="$(run_kubectl get "deployment/$deployment" -n "$namespace" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)"
+    if [ -z "$desired" ] || [ "${available:-0}" -lt "$desired" ]; then
+      return 1
+    fi
+  done
+}
+
+wait_rollouts() {
+  local deployment service name
+  if [ "$#" -eq 0 ]; then
+    for deployment in "${deployments[@]}"; do
+      run_kubectl rollout status "deployment/$deployment" -n "$namespace" --timeout="${ROLLOUT_TIMEOUT:-300s}"
+    done
+  else
+    while IFS= read -r service; do
+      name="${service%%:*}"
+      deployment="$(deployment_for_service "$name")"
+      run_kubectl rollout status "deployment/$deployment" -n "$namespace" --timeout="${ROLLOUT_TIMEOUT:-300s}"
+    done < <(selected_services "$@")
+  fi
+  run_kubectl wait --for=condition=complete job/seed-user-pool -n "$namespace" --timeout="${JOB_TIMEOUT:-300s}"
+}
+
+api_check() {
+  DEMO_USER="${DEMO_USER:-harper.clark.001}" \
+  DEMO_PASSWORD="${DEMO_PASSWORD:-SimUser123!}" \
+  EXPECT_TRANSFER_REVIEW=true \
+  kubectl --context "$context" -n "$namespace" exec deploy/banking-sim -- \
+    env DEMO_USER="${DEMO_USER:-harper.clark.001}" DEMO_PASSWORD="${DEMO_PASSWORD:-SimUser123!}" EXPECT_TRANSFER_REVIEW=true \
+    node --input-type=module -e '
+const base = "http://banking-gateway:80";
+const username = process.env.DEMO_USER;
+const password = process.env.DEMO_PASSWORD;
+const maxAttempts = Number(process.env.API_CHECK_ATTEMPTS || 20);
+const retryDelayMs = Number(process.env.API_CHECK_RETRY_DELAY_MS || 1000);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function call(path, opts = {}) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(base + path, opts);
+      const text = await response.text();
+      let data = null;
+      try { data = text ? JSON.parse(text) : null; } catch { data = text; }
+
+      if (response.status < 500 || attempt === maxAttempts) {
+        return { status: response.status, data, text };
+      }
+      lastError = new Error(`${path} returned ${response.status}: ${text}`);
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+    }
+
+    await sleep(retryDelayMs);
+  }
+
+  throw lastError || new Error(`failed to call ${path}`);
+}
+
+async function post(path, body, token) {
+  return call(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const login = await post("/api/users/login", { usernameOrEmail: username, password });
+if (login.status !== 200 || !login.data?.token) throw new Error(`login returned ${login.status}: ${login.text}`);
+const token = login.data.token;
+const accountsResponse = await call("/api/accounts", { headers: { authorization: `Bearer ${token}` } });
+if (accountsResponse.status !== 200) throw new Error(`accounts returned ${accountsResponse.status}: ${accountsResponse.text}`);
+
+const accounts = accountsResponse.data;
+const checking = accounts.filter((account) => account.accountType === "CHECKING");
+const savings = accounts.filter((account) => account.accountType === "SAVINGS");
+if (checking.length !== 1 || savings.length !== 1) throw new Error(`expected one checking and one savings, got checking=${checking.length} savings=${savings.length}`);
+if (Number(checking[0].balance) < 1000 || Number(savings[0].balance) < 500) throw new Error("demo accounts are not funded enough");
+
+const transfer = await post("/api/transactions/transfer", {
+  fromAccountId: checking[0].id,
+  toAccountId: savings[0].id,
+  amount: 125,
+  description: "Emergency fund transfer",
+}, token);
+if (transfer.status !== 400) throw new Error(`expected transfer compliance review status 400, got ${transfer.status}: ${transfer.text}`);
+
+console.log(JSON.stringify({ ok: true, user: username, checking: checking[0], savings: savings[0], transferStatus: transfer.status }, null, 2));
+'
+}
+
+port_forward() {
+  run_kubectl port-forward -n "$namespace" service/banking-frontend "$frontend_port:80"
+}
+
+browser_check() {
+  port_forward_pid=""
+  local frontend_pod local_port log_file
+
+  frontend_pod="$(run_kubectl get pod -n "$namespace" -l app=banking-frontend --field-selector=status.phase=Running --sort-by=.metadata.creationTimestamp -o name | tail -n 1)"
+  if [ -z "$frontend_pod" ]; then
+    echo "frontend pod not found" >&2
+    exit 1
+  fi
+  run_kubectl wait --for=condition=Ready "$frontend_pod" -n "$namespace" --timeout="${FRONTEND_READY_TIMEOUT:-120s}"
+
+  local_port="${BROWSER_FRONTEND_PORT:-$((3100 + RANDOM % 1000))}"
+  log_file="/tmp/microsvc-frontend-port-forward.$$.log"
+  run_kubectl port-forward -n "$namespace" "$frontend_pod" "$local_port:3000" >"$log_file" 2>&1 &
+  port_forward_pid="$!"
+  trap 'if [ -n "${port_forward_pid:-}" ]; then kill "$port_forward_pid" 2>/dev/null || true; fi' EXIT
+
+  for _ in $(seq 1 20); do
+    if ! kill -0 "$port_forward_pid" 2>/dev/null; then
+      cat "$log_file" >&2
+      exit 1
+    fi
+    if grep -q "Forwarding from" "$log_file"; then
+      break
+    fi
+    sleep 0.5
+  done
+
+  BASE_URL="http://127.0.0.1:$local_port" node "$repo_root/scripts/demo-story-browser-check.mjs"
+}
+
+traffic_check() {
+  node "$repo_root/scripts/demo-story-traffic-check.mjs" "$@"
+}
+
+web_check() {
+  "$repo_root/scripts/demo-story-web-check.sh" "$@"
+}
+
+replay_check() {
+  "$repo_root/scripts/demo-story-replay-check.sh" "$@"
+}
+
+transfer_replay_check() {
+  "$repo_root/scripts/demo-story-transfer-replay-check.sh" "$@"
+}
+
+fresh_capture_check() {
+  bash "$repo_root/scripts/demo-story-fresh-capture-check.sh" "$@"
+}
+
+run_once() {
+  start_minikube
+  build_images "$@"
+  deploy_local "$@"
+  api_check
+  browser_check
+}
+
+loop_forever() {
+  local iteration service name delay
+  iteration=1
+  delay="${LOOP_DELAY_SECONDS:-0}"
+
+  while true; do
+    while IFS= read -r service; do
+      name="${service%%:*}"
+      echo "Loop $iteration: $name"
+      run_once "$name"
+      iteration=$((iteration + 1))
+      if [ "$delay" -gt 0 ]; then
+        sleep "$delay"
+      fi
+    done < <(selected_services "$@")
+  done
+}
+
+status() {
+  run_kubectl get pods,svc -n "$namespace"
+}
+
+clean() {
+  run_kubectl delete -k "$overlay" --ignore-not-found
+}
+
+cmd="${1:-}"
+if [ -z "$cmd" ]; then
+  usage
+  exit 2
+fi
+shift || true
+
+case "$cmd" in
+  start-minikube) start_minikube ;;
+  build) build_images "$@" ;;
+  deploy) deploy_local "$@" ;;
+  api-check) api_check ;;
+  browser-check) browser_check ;;
+  traffic-check) traffic_check "$@" ;;
+  web-check) web_check "$@" ;;
+  replay-check) replay_check "$@" ;;
+  transfer-replay-check) transfer_replay_check "$@" ;;
+  fresh-capture-check) fresh_capture_check "$@" ;;
+  once) run_once "$@" ;;
+  loop) loop_forever "$@" ;;
+  port-forward) port_forward ;;
+  status) status ;;
+  clean) clean ;;
+  -h|--help|help) usage ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/demo-story-replay-check.sh
+++ b/scripts/demo-story-replay-check.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+config_file="${DEMO_LOOP_CONFIG:-$HOME/spd-workspace/speedstack/instances/microsvc-demo-mini/minikube.env}"
+if [ -f "$config_file" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$config_file"
+  set +a
+fi
+
+context="${KUBE_CONTEXT:-${MINIKUBE_PROFILE:-speedscale-demo-mini}}"
+namespace="${NAMESPACE:-banking-app}"
+capture_dir="${1:-${PROXYMOCK_CAPTURE_DIR:-}}"
+local_port="${REPLAY_GATEWAY_PORT:-$((18080 + RANDOM % 1000))}"
+tmp_dir="$(mktemp -d "/tmp/microsvc-proxymock-replay.XXXXXX")"
+port_forward_pid=""
+log_file="/tmp/microsvc-gateway-port-forward.$$.log"
+
+cleanup() {
+  if [ -n "${port_forward_pid:-}" ]; then
+    kill "$port_forward_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir" "$log_file"
+}
+trap cleanup EXIT
+
+SOURCE_CAPTURE="$capture_dir" OUT_DIR="$tmp_dir" REPO_ROOT="$repo_root" node --input-type=module - <<'NODE'
+import fs from "fs";
+import path from "path";
+
+const repoRoot = process.env.REPO_ROOT;
+const proxymockRoot = path.join(repoRoot, "backend", "ai-service", "proxymock");
+const out = process.env.OUT_DIR;
+
+function newestCaptureDir() {
+  if (!fs.existsSync(proxymockRoot)) {
+    return null;
+  }
+  return fs.readdirSync(proxymockRoot)
+    .map((name) => path.join(proxymockRoot, name))
+    .filter((entry) => fs.statSync(entry).isDirectory())
+    .filter((entry) => /^(live|imported-s3)-/.test(path.basename(entry)))
+    .map((entry) => ({ entry, mtime: fs.statSync(entry).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime)[0]?.entry || null;
+}
+
+function readRRPair(file) {
+  const text = fs.readFileSync(file, "utf8");
+  if (file.endsWith(".json")) {
+    return JSON.parse(text);
+  }
+  const line = text.split("\n").reverse().find((entry) => entry.startsWith("json: "));
+  return line ? JSON.parse(line.slice("json: ".length)) : null;
+}
+
+const capture = process.env.SOURCE_CAPTURE || newestCaptureDir();
+if (!capture) {
+  throw new Error("no proxymock capture directory found");
+}
+
+const localhost = path.join(capture, "localhost");
+if (!fs.existsSync(localhost)) {
+  throw new Error(`capture has no localhost replay directory: ${capture}`);
+}
+
+const replayHostDir = path.join(out, "localhost");
+fs.mkdirSync(replayHostDir, { recursive: true });
+
+let copied = 0;
+for (const name of fs.readdirSync(localhost).sort()) {
+  if (!name.endsWith(".md") && !name.endsWith(".json")) {
+    continue;
+  }
+  const file = path.join(localhost, name);
+  let rrpair;
+  try {
+    rrpair = readRRPair(file);
+  } catch {
+    continue;
+  }
+  if (rrpair?.service === "banking-gateway" && rrpair.command === "POST" && rrpair.location === "/api/users/login") {
+    fs.copyFileSync(file, path.join(replayHostDir, name));
+    copied += 1;
+    if (copied >= Number(process.env.REPLAY_SAMPLE_SIZE || 3)) {
+      break;
+    }
+  }
+}
+
+console.error(JSON.stringify({ capture, replayDir: out, copied }, null, 2));
+if (copied === 0) {
+  throw new Error("no captured banking-gateway /api/users/login requests found");
+}
+NODE
+
+kubectl --context "$context" -n "$namespace" port-forward service/banking-gateway "$local_port:80" >"$log_file" 2>&1 &
+port_forward_pid="$!"
+
+for _ in $(seq 1 20); do
+  if ! kill -0 "$port_forward_pid" 2>/dev/null; then
+    cat "$log_file" >&2
+    exit 1
+  fi
+  if grep -q "Forwarding from" "$log_file"; then
+    break
+  fi
+  sleep 0.5
+done
+
+proxymock replay \
+  --in "$tmp_dir" \
+  --test-against "http://127.0.0.1:$local_port" \
+  --rewrite-host \
+  --fail-if "requests.failed!=0" \
+  --fail-if "requests.result-match-pct<100" \
+  --output json \
+  --no-out

--- a/scripts/demo-story-traffic-check.mjs
+++ b/scripts/demo-story-traffic-check.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const proxymockRoot = path.join(repoRoot, "backend", "ai-service", "proxymock");
+
+function usage() {
+  console.error("Usage: scripts/demo-story-traffic-check.mjs [capture-dir]");
+}
+
+function newestCaptureDir() {
+  if (!fs.existsSync(proxymockRoot)) {
+    return null;
+  }
+
+  const candidates = fs.readdirSync(proxymockRoot)
+    .map((name) => path.join(proxymockRoot, name))
+    .filter((entry) => fs.statSync(entry).isDirectory())
+    .filter((entry) => /^(live|imported-s3)-/.test(path.basename(entry)))
+    .map((entry) => ({ entry, mtime: fs.statSync(entry).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  return candidates[0]?.entry || null;
+}
+
+function walk(dir, files = []) {
+  for (const name of fs.readdirSync(dir)) {
+    const file = path.join(dir, name);
+    const stat = fs.statSync(file);
+    if (stat.isDirectory()) {
+      walk(file, files);
+    } else if (name.endsWith(".md") || name.endsWith(".json")) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
+function parseRRPair(file) {
+  const text = fs.readFileSync(file, "utf8");
+  if (file.endsWith(".json")) {
+    return JSON.parse(text);
+  }
+
+  const line = text.split("\n").reverse().find((entry) => entry.startsWith("json: "));
+  if (!line) {
+    return null;
+  }
+  return JSON.parse(line.slice("json: ".length));
+}
+
+function increment(map, key) {
+  map.set(key, (map.get(key) || 0) + 1);
+}
+
+function top(map, limit = 12) {
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([name, count]) => ({ name, count }));
+}
+
+const requestedDir = process.argv[2] || process.env.PROXYMOCK_CAPTURE_DIR;
+if (process.argv.includes("-h") || process.argv.includes("--help")) {
+  usage();
+  process.exit(0);
+}
+
+const captureDir = requestedDir ? path.resolve(requestedDir) : newestCaptureDir();
+if (!captureDir || !fs.existsSync(captureDir)) {
+  console.error("No proxymock capture directory found.");
+  usage();
+  process.exit(2);
+}
+
+const files = walk(captureDir);
+const byHost = new Map();
+const byService = new Map();
+const byTech = new Map();
+const endpointSamples = [];
+let parsed = 0;
+
+for (const file of files) {
+  let rrpair;
+  try {
+    rrpair = parseRRPair(file);
+  } catch {
+    continue;
+  }
+  if (!rrpair) {
+    continue;
+  }
+
+  parsed += 1;
+  const host = path.basename(path.dirname(file));
+  increment(byHost, host);
+  increment(byService, rrpair.service || "unknown");
+  increment(byTech, rrpair.tech || rrpair.l7protocol || "unknown");
+
+  if (endpointSamples.length < 20 && rrpair.command && rrpair.location) {
+    endpointSamples.push({
+      host,
+      service: rrpair.service || "unknown",
+      command: rrpair.command,
+      location: rrpair.location,
+      status: rrpair.status || "unknown",
+    });
+  }
+}
+
+const hosts = new Set(byHost.keys());
+const services = new Set(byService.keys());
+const requiredEvidence = [
+  ["frontend traffic", services.has("banking-frontend")],
+  ["gateway traffic", services.has("banking-gateway") || hosts.has("banking-gateway")],
+  ["accounts traffic", services.has("banking-accounts") || hosts.has("banking-accounts")],
+  ["transactions traffic", services.has("banking-transactions") || hosts.has("banking-transactions")],
+  ["user traffic", services.has("banking-user") || hosts.has("banking-user")],
+  ["fraud gRPC traffic", hosts.has("banking-fraud")],
+  ["notification traffic", services.has("banking-notification") || hosts.has("banking-notification")],
+  ["database traffic", [...hosts].some((host) => host.includes("postgres"))],
+  ["cache traffic", [...hosts].some((host) => host.includes("redis"))],
+  ["kafka traffic", [...hosts].some((host) => host.includes("kafka"))],
+  ["external API traffic", [...hosts].some((host) => !host.startsWith("banking-") && host !== "localhost")],
+];
+
+const failures = [];
+if (parsed < 50) {
+  failures.push(`expected at least 50 parsed RRPairs, got ${parsed}`);
+}
+for (const [label, ok] of requiredEvidence) {
+  if (!ok) {
+    failures.push(`missing ${label}`);
+  }
+}
+
+const result = {
+  ok: failures.length === 0,
+  captureDir,
+  files: files.length,
+  parsed,
+  topHosts: top(byHost),
+  topServices: top(byService),
+  topTech: top(byTech),
+  endpointSamples,
+  failures,
+};
+
+console.log(JSON.stringify(result, null, 2));
+if (failures.length > 0) {
+  process.exit(1);
+}

--- a/scripts/demo-story-transfer-replay-check.sh
+++ b/scripts/demo-story-transfer-replay-check.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+config_file="${DEMO_LOOP_CONFIG:-$HOME/spd-workspace/speedstack/instances/microsvc-demo-mini/minikube.env}"
+if [ -f "$config_file" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$config_file"
+  set +a
+fi
+
+context="${KUBE_CONTEXT:-${MINIKUBE_PROFILE:-speedscale-demo-mini}}"
+namespace="${NAMESPACE:-banking-app}"
+gateway_port="${TRANSFER_REPLAY_GATEWAY_PORT:-$((23000 + RANDOM % 1000))}"
+record_port="${TRANSFER_REPLAY_RECORD_PORT:-$((24000 + RANDOM % 1000))}"
+health_port="${TRANSFER_REPLAY_HEALTH_PORT:-$((25000 + RANDOM % 1000))}"
+capture_dir="${TRANSFER_REPLAY_CAPTURE_DIR:-$(mktemp -d "/tmp/microsvc-transfer-capture.XXXXXX")}"
+replay_out="${TRANSFER_REPLAY_OUT_DIR:-$(mktemp -d "/tmp/microsvc-transfer-replay.XXXXXX")}"
+gateway_log="/tmp/microsvc-gateway-port-forward.$$.log"
+record_log="/tmp/microsvc-proxymock-record.$$.log"
+gateway_pid=""
+record_pid=""
+
+cleanup() {
+  if [ -n "${record_pid:-}" ]; then
+    kill "$record_pid" 2>/dev/null || true
+  fi
+  if [ -n "${gateway_pid:-}" ]; then
+    kill "$gateway_pid" 2>/dev/null || true
+  fi
+  rm -f "$gateway_log" "$record_log"
+}
+trap cleanup EXIT
+
+kubectl --context "$context" -n "$namespace" port-forward service/banking-gateway "$gateway_port:80" >"$gateway_log" 2>&1 &
+gateway_pid="$!"
+
+for _ in $(seq 1 20); do
+  if ! kill -0 "$gateway_pid" 2>/dev/null; then
+    cat "$gateway_log" >&2
+    exit 1
+  fi
+  if grep -q "Forwarding from" "$gateway_log"; then
+    break
+  fi
+  sleep 0.5
+done
+
+proxymock record \
+  --app-port "$gateway_port" \
+  --proxy-in-port "$record_port" \
+  --health-port "$health_port" \
+  --out "$capture_dir" \
+  --svc-name banking-gateway \
+  --out-format markdown >"$record_log" 2>&1 &
+record_pid="$!"
+
+for _ in $(seq 1 30); do
+  if ! kill -0 "$record_pid" 2>/dev/null; then
+    cat "$record_log" >&2
+    exit 1
+  fi
+  if curl -fsS "http://127.0.0.1:$health_port" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+
+RECORD_BASE_URL="http://127.0.0.1:$record_port" node --input-type=module - <<'NODE'
+const base = process.env.RECORD_BASE_URL;
+const username = process.env.DEMO_USER || "harper.clark.001";
+const password = process.env.DEMO_PASSWORD || "SimUser123!";
+
+async function request(path, opts = {}) {
+  const response = await fetch(base + path, opts);
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text;
+  }
+  return { response, text, data };
+}
+
+async function post(path, body, token) {
+  return request(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const login = await post("/api/users/login", { usernameOrEmail: username, password });
+if (login.response.status !== 200 || !login.data?.token) {
+  throw new Error(`login returned ${login.response.status}: ${login.text}`);
+}
+
+const accounts = await request("/api/accounts", {
+  headers: { authorization: `Bearer ${login.data.token}` },
+});
+if (accounts.response.status !== 200 || !Array.isArray(accounts.data)) {
+  throw new Error(`accounts returned ${accounts.response.status}: ${accounts.text}`);
+}
+
+const checking = accounts.data.find((account) => account.accountType === "CHECKING");
+const savings = accounts.data.find((account) => account.accountType === "SAVINGS");
+if (!checking || !savings) {
+  throw new Error("checking/savings accounts not found");
+}
+
+const transfer = await post("/api/transactions/transfer", {
+  fromAccountId: checking.id,
+  toAccountId: savings.id,
+  amount: 125,
+  description: "Emergency fund transfer",
+}, login.data.token);
+if (transfer.response.status !== 400) {
+  throw new Error(`expected transfer review status 400, got ${transfer.response.status}: ${transfer.text}`);
+}
+
+console.error(JSON.stringify({
+  recorded: true,
+  user: username,
+  checking: checking.id,
+  savings: savings.id,
+  transferStatus: transfer.response.status,
+}, null, 2));
+NODE
+
+sleep 1
+kill "$record_pid" 2>/dev/null || true
+record_pid=""
+
+if ! find "$capture_dir" -type f | grep -q .; then
+  cat "$record_log" >&2
+  echo "proxymock record wrote no files to $capture_dir" >&2
+  exit 1
+fi
+
+replay_json="$(proxymock replay \
+  --in "$capture_dir" \
+  --test-against "http://127.0.0.1:$gateway_port" \
+  --rewrite-host \
+  --fail-if "requests.failed!=0" \
+  --out "$replay_out" \
+  --output json)"
+
+REPLAY_JSON="$replay_json" CAPTURE_DIR="$capture_dir" REPLAY_OUT="$replay_out" node --input-type=module - <<'NODE'
+const replay = JSON.parse(process.env.REPLAY_JSON);
+const transfer = replay.endpoints?.find((endpoint) => endpoint.url === "/api/transactions/transfer");
+if (!transfer) {
+  throw new Error("replay output did not include /api/transactions/transfer");
+}
+if (transfer.metrics?.["requests.failed"] !== 0 || transfer.metrics?.["requests.succeeded"] < 1) {
+  throw new Error(`transfer replay failed: ${JSON.stringify(transfer.metrics)}`);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  captureDir: process.env.CAPTURE_DIR,
+  replayOut: process.env.REPLAY_OUT,
+  transfer: transfer.metrics,
+}, null, 2));
+NODE

--- a/scripts/demo-story-web-check.mjs
+++ b/scripts/demo-story-web-check.mjs
@@ -1,0 +1,79 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(new URL('../frontend/package.json', import.meta.url));
+const { chromium } = require('@playwright/test');
+
+const baseURL = process.env.PROXYMOCK_WEB_URL || 'http://127.0.0.1:7788';
+const runName = process.env.PROXYMOCK_WEB_RUN || 'live-banking-ai-2026-06-19_12-48-06';
+const minRows = Number(process.env.PROXYMOCK_WEB_MIN_ROWS || 100);
+const headless = process.env.HEADLESS !== 'false';
+const requiredText = (process.env.PROXYMOCK_WEB_REQUIRED_TEXT
+  ? process.env.PROXYMOCK_WEB_REQUIRED_TEXT.split(',').map((item) => item.trim()).filter(Boolean)
+  : [
+      runName,
+      'Pull',
+      'Replay',
+      'banking-transactions',
+      'api.complyadvantage.com',
+      'banking-accounts',
+      'api.ratings.moodys.com',
+    ]);
+
+const browser = await chromium.launch({ headless });
+const page = await browser.newPage();
+
+async function fail(message) {
+  await browser.close();
+  throw new Error(message);
+}
+
+await page.goto(baseURL, { waitUntil: 'domcontentloaded' });
+await page.getByText('proxymock').first().waitFor({ timeout: 15000 });
+await page.getByRole('button', { name: 'Pull' }).waitFor({ timeout: 15000 });
+await page.getByRole('button', { name: /Replay/ }).waitFor({ timeout: 15000 });
+
+const runSelector = page.locator('select').first();
+await runSelector.waitFor({ timeout: 15000 });
+const options = await runSelector.locator('option').allTextContents();
+if (!options.includes(runName)) {
+  await fail(`run selector did not include ${runName}; options=${options.join(', ')}`);
+}
+
+await runSelector.selectOption({ label: runName });
+await page.waitForFunction((minimumRows) => {
+  const text = document.body?.innerText || '';
+  const match = text.match(/\bof\s+([0-9,]+)/);
+  if (!match) {
+    return false;
+  }
+  return Number(match[1].replace(/,/g, '')) >= minimumRows;
+}, minRows, { timeout: 15000 });
+
+await page.waitForFunction((required) => {
+  const text = document.body?.innerText || '';
+  return required.every((item) => text.includes(item));
+}, requiredText, { timeout: 15000 });
+
+const visibleRows = await page.locator('[role="row"]').count();
+const bodyText = await page.locator('body').innerText();
+
+for (const text of requiredText) {
+  if (!bodyText.includes(text)) {
+    await fail(`proxymock web did not show ${text}`);
+  }
+}
+
+const rowSummary = await page.locator('[role="row"]').evaluateAll((rows) => rows
+  .slice(1, 6)
+  .map((row) => row.textContent?.replace(/\s+/g, ' ').trim())
+  .filter(Boolean));
+
+console.log(JSON.stringify({
+  ok: true,
+  baseURL,
+  runName,
+  visibleRows,
+  rowSummary,
+}, null, 2));
+
+await browser.close();

--- a/scripts/demo-story-web-check.sh
+++ b/scripts/demo-story-web-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+workspace="${PROXYMOCK_WEB_WORKSPACE:-$repo_root/backend/ai-service/proxymock}"
+run_name="${PROXYMOCK_WEB_RUN:-live-banking-ai-2026-06-19_12-48-06}"
+port="${PROXYMOCK_WEB_PORT:-$((7788 + RANDOM % 1000))}"
+log_file="/tmp/microsvc-proxymock-web.$$.log"
+web_pid=""
+
+cleanup() {
+  if [ -n "${web_pid:-}" ]; then
+    kill "$web_pid" 2>/dev/null || true
+  fi
+  rm -f "$log_file"
+}
+trap cleanup EXIT
+
+proxymock web \
+  --in "$workspace" \
+  --host 127.0.0.1 \
+  --port "$port" \
+  --open=false \
+  --chat=false \
+  --forwarder-addr '' >"$log_file" 2>&1 &
+web_pid="$!"
+
+for _ in $(seq 1 60); do
+  if ! kill -0 "$web_pid" 2>/dev/null; then
+    cat "$log_file" >&2
+    exit 1
+  fi
+  if grep -q "analysis complete" "$log_file"; then
+    break
+  fi
+  sleep 1
+done
+
+PROXYMOCK_WEB_URL="http://127.0.0.1:$port" \
+PROXYMOCK_WEB_RUN="$run_name" \
+node "$repo_root/scripts/demo-story-web-check.mjs"


### PR DESCRIPTION
## Summary
- add a minikube-based demo story loop for the banking app
- add checks for seeded user login, browser transfer-review path, proxymock capture inventory, proxymock web visibility, replay, and fresh local capture
- keep generated proxymock live/imported/local-transfer runs out of git

## Verification
- speedstack worktree wrapper: ./run.sh api-check
- speedstack worktree wrapper: ./run.sh browser-check
- speedstack worktree wrapper: ./run.sh traffic-check
- speedstack worktree wrapper: ./run.sh web-check
- speedstack worktree wrapper: ./run.sh replay-check
- speedstack worktree wrapper: ./run.sh fresh-capture-check

Forwarder -> S3 -> proxymock pull is handled separately in speedscale/speedscale!6539.