### PR TITLE
Standardize fraud service port

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ kubectl apply -k kubernetes/overlays/local/
 | `accounts-service` | Java (Spring Boot) | Account + balance management, Plaid integration |
 | `transactions-service` | Java (Spring Boot) | Transaction processing, Stripe / PayPal / ComplyAdvantage integrations |
 | `ai-service` | Python (FastAPI) | Chat endpoint that fans out to 5 LLM providers (Anthropic, OpenAI, Gemini, xAI, OpenRouter) and aggregates the replies |
-| `fraud-service` | Go (gRPC h2c on :50051) | Fraud risk scoring with Sift / MaxMind / Stripe Radar |
+| `fraud-service` | Go (gRPC h2c on :8080) | Fraud risk scoring with Sift / MaxMind / Stripe Radar |
 | `notification-service` | Go | Slack / SendGrid / Twilio fan-out for transaction events from Kafka |
 | `mongo-service` | Java | Mongo-backed user-data store |
 | `frontend` | Next.js 15 / React 19 | Server-side proxy + UI |
@@ -270,7 +270,7 @@ curl http://localhost:8083/actuator/health  # Transactions Service
 curl http://localhost:8084/health           # AI Service (FastAPI)
 curl http://localhost:8085/health           # Notification Service (Go)
 curl http://localhost:3000/api/health       # Frontend
-# fraud-service speaks gRPC; use `grpcurl localhost:50051 list`
+# fraud-service speaks gRPC; use `grpcurl localhost:8086 list`
 ```
 
 ---

--- a/backend/fraud-service/Dockerfile
+++ b/backend/fraud-service/Dockerfile
@@ -17,6 +17,6 @@ COPY --from=builder /fraud-service /usr/local/bin/fraud-service
 
 USER fraud
 
-EXPOSE 50051 9091
+EXPOSE 8080 9091
 
 ENTRYPOINT ["fraud-service"]

--- a/backend/fraud-service/cmd/server/main.go
+++ b/backend/fraud-service/cmd/server/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	port := envOrDefault("GRPC_PORT", "50051")
+	port := envOrDefault("GRPC_PORT", "8080")
 	metricsPort := envOrDefault("METRICS_PORT", "9091")
 
 	go serveMetrics(metricsPort)

--- a/backend/transactions-service/pom.xml
+++ b/backend/transactions-service/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.banking</groupId>
     <artifactId>transactions-service</artifactId>
-    <version>1.4.99</version>
+    <version>1.4.100</version>
     <packaging>jar</packaging>
 
     <name>transactions-service</name>

--- a/backend/transactions-service/src/main/resources/application.yml
+++ b/backend/transactions-service/src/main/resources/application.yml
@@ -57,7 +57,7 @@ accounts:
 grpc:
   client:
     fraud-service:
-      address: static://${FRAUD_SERVICE_HOST:banking-fraud}:${FRAUD_SERVICE_PORT:50051}
+      address: static://${FRAUD_SERVICE_HOST:banking-fraud}:${FRAUD_SERVICE_PORT:8080}
       negotiation-type: plaintext
 
 kafka:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       # Service URLs
       - ACCOUNTS_SERVICE_URL=http://accounts-service:8080
       - FRAUD_SERVICE_HOST=fraud-service
-      - FRAUD_SERVICE_PORT=50051
+      - FRAUD_SERVICE_PORT=8080
       # OpenTelemetry Configuration
       - OTEL_SERVICE_NAME=transactions-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
@@ -129,10 +129,10 @@ services:
       dockerfile: Dockerfile
     container_name: banking-fraud-service
     environment:
-      - GRPC_PORT=50051
+      - GRPC_PORT=8080
       - METRICS_PORT=9091
     ports:
-      - "50051:50051"
+      - "8086:8080"
     networks:
       - banking-network
 

--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -17,7 +17,7 @@ data:
   ACCOUNTS_SERVICE_URL: "http://banking-accounts:80"
   TRANSACTIONS_SERVICE_URL: "http://banking-transactions:80"
   FRAUD_SERVICE_HOST: "banking-fraud"
-  FRAUD_SERVICE_PORT: "50051"
+  FRAUD_SERVICE_PORT: "8080"
   NOTIFICATION_SERVICE_URL: "http://banking-notification:80"
   KAFKA_BROKERS: "banking-kafka:9092"
 

--- a/kubernetes/base/deployments/fraud-service-deployment.yaml
+++ b/kubernetes/base/deployments/fraud-service-deployment.yaml
@@ -28,13 +28,13 @@ spec:
         image: ghcr.io/speedscale/microsvc/fraud-service:v1.4.99
         imagePullPolicy: Always
         ports:
-        - containerPort: 50051
+        - containerPort: 8080
           name: grpc
         - containerPort: 9091
           name: metrics
         env:
         - name: GRPC_PORT
-          value: "50051"
+          value: "8080"
         - name: METRICS_PORT
           value: "9091"
         envFrom:
@@ -49,7 +49,7 @@ spec:
             cpu: "100m"
         readinessProbe:
           tcpSocket:
-            port: 50051
+            port: grpc
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5

--- a/kubernetes/base/services/fraud-service-service.yaml
+++ b/kubernetes/base/services/fraud-service-service.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 50051
-    targetPort: 50051
+  - port: 8080
+    targetPort: grpc
     protocol: TCP
     name: grpc
   - port: 9091


### PR DESCRIPTION
## Summary

- Change fraud-service gRPC listener default from `50051` to `8080`.
- Update Docker Compose, Kubernetes service/deployment, and transactions-service caller config to use `8080`.
- Keep the dedicated metrics listener on `9091` and map local Compose access to `localhost:8086` to avoid existing demo port conflicts.
- Bump transactions-service to `1.4.100` for the backend config change.

## Why

The fraud app was using the gRPC convention port `50051` while the rest of the demo uses HTTP-style service ports. This makes the runtime and Kubernetes service wiring use the expected `8080` service port consistently.

## Validation

- `go test ./...` from `backend/fraud-service`
- `kubectl kustomize kubernetes/base`
- Verified there are no remaining live `50051` references outside generated/recorded/proxymock data