### PR TITLE
Replay Lab demo fixture: flag-gated null-memo deposit bug (default OFF)

### DIFF
--- a/backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
+++ b/backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,6 +76,12 @@ public class TransactionService {
     @Autowired
     private DoubleHistogram transferAmountHistogram;
 
+    // Demo fixture flag (default OFF). When enabled, deposit() normalizes the
+    // memo for the ledger feed and trips on a null description. Used to stage a
+    // reproducible bug for the Replay Lab demo. Never enable in production.
+    @Value("${demo.memo-bug.enabled:false}")
+    private boolean memoBugEnabled;
+
     private final ConcurrentMap<Long, ReentrantLock> accountLocks = new ConcurrentHashMap<>();
     
     public List<TransactionResponse> getUserTransactions(Long userId) {
@@ -96,6 +103,12 @@ public class TransactionService {
     public TransactionResponse deposit(DepositRequest request, Long userId, HttpServletRequest httpRequest) {
         logger.info("Processing deposit for user: {}, account: {}, amount: {}",
                    userId, request.getAccountId(), request.getAmount());
+
+        if (memoBugEnabled) {
+            // Normalize the transaction memo for the downstream ledger feed.
+            String memo = request.getDescription().trim().toUpperCase();
+            logger.debug("Normalized ledger memo ({} chars) for account {}", memo.length(), request.getAccountId());
+        }
 
         // Fraud check before processing
         var fraudResult = fraudServiceClient.checkTransaction(

--- a/backend/transactions-service/src/main/resources/application.yml
+++ b/backend/transactions-service/src/main/resources/application.yml
@@ -119,3 +119,10 @@ otel:
   span:
     name:
       pattern: "{http.method} {http.route}"
+
+# Demo fixtures (default OFF). Enable for the Replay Lab demo only: deposit()
+# normalizes the memo and NPEs (-> 500) on a null description. Set
+# DEMO_MEMO_BUG_ENABLED=true on staging-decoy during recording. Never in prod.
+demo:
+  memo-bug:
+    enabled: ${DEMO_MEMO_BUG_ENABLED:false}

--- a/simulation-client/src/workflows/UserWorkflow.js
+++ b/simulation-client/src/workflows/UserWorkflow.js
@@ -584,6 +584,7 @@ class UserWorkflow {
       'serviceUnavailable',                                  // 503 /api/accounts/{id}/export-statement
       'badLogin',                                            // 401 (light realism)
       'expiredToken',                                        // 401 (light realism)
+      'nullDescriptionDeposit',                              // 200 normally; 500 when demo.memo-bug.enabled (Replay Lab fixture)
     ];
     const scenario = bag[Math.floor(Math.random() * bag.length)];
 
@@ -598,6 +599,18 @@ class UserWorkflow {
 
         case 'expiredToken':
           await this.apiClient.getAccounts('invalid.expired.token');
+          break;
+
+        case 'nullDescriptionDeposit':
+          // Replay Lab fixture: a deposit with no description field. Succeeds (200)
+          // normally; returns 500 only when transactions-service runs with
+          // demo.memo-bug.enabled=true (the planted null-memo regression).
+          if (account) {
+            await this.apiClient.deposit({
+              amount: 50,
+              accountId: account.id,
+            }, user.token);
+          }
           break;
 
         case 'missingAccount':


### PR DESCRIPTION
## What
Stages **one deterministic, reproducible 500** for the Replay Lab video demo (the through-line request that threads Grafana → proxymock RRPair → replay reproduce/fix).

- **transactions-service** — `deposit()` normalizes the ledger memo and trips a `NullPointerException` (→ opaque 500, not a 400) when `description` is null. Gated by `demo.memo-bug.enabled` (default `false`, env `DEMO_MEMO_BUG_ENABLED`). Placed **before** the fraud/accounts calls so an inbound-only replay reproduces it without downstream mocks.
- **simulation-client** — `nullDescriptionDeposit` scenario in the error-bag sends a description-less deposit. Returns **200 normally**; **500 only when the flag is on**.

## Why a 500, not a 400
The `GlobalExceptionHandler` turns only validation errors into a 400 with a clear field message — which would *undercut* the demo (observability would already tell you what broke). An unhandled NPE falls through to an opaque 500: the trace shows where it threw, never the payload. That's the bug we want.

## Safety
**Default OFF — safe to merge with zero behavior change.** Nothing 500s until the flag is set. The sim scenario returns 200 while the flag is off.

## How to go live (recording only)
1. Set `DEMO_MEMO_BUG_ENABLED=true` on the `banking-transactions` deployment in staging-decoy.
2. Error injection is already on (`ERROR_INJECTION_PROBABILITY=0.05`); the sim then drives description-less deposits → 5xx on `banking-transactions`.
3. Or drive it directly: `POST /api/transactions/deposit {"accountId":<id>,"amount":50}` (no `description`).
4. The agent's fix (beat 6) is the one-line null guard: `request.getDescription() == null ? "" : request.getDescription().trim()...`.

## Verified
- `mvn compile` clean.
- Unit-level: flag on + null description throws NPE (confirmed via a throwaway test, not committed).

Do **not** enable in production. Revert the flag (or this PR) after the shoot.