### PR TITLE
Pin seeded customer-user ids for replay determinism

### DIFF
--- a/database/migrations/user-service/V2__Seed_simulation_users.sql
+++ b/database/migrations/user-service/V2__Seed_simulation_users.sql
@@ -74,9 +74,18 @@ $$ LANGUAGE plpgsql;
 
 SELECT setseed(0.42);
 
--- Insert reusable customer users
-INSERT INTO user_service.users (username, email, password_hash, roles, created_at, updated_at)
-SELECT 
+-- Insert reusable customer users.
+--
+-- Pin the id to the seed number (1..1000) instead of letting BIGSERIAL assign it.
+-- Why: recorded traffic carries JWTs whose `userId` claim is the seeded user's id,
+-- and downstream account ownership is keyed on that id. With an unpinned BIGSERIAL,
+-- every reseed hands a given seed user a different id, so previously-recorded JWTs
+-- (and the accounts they own) go stale -- which makes traffic replay non-deterministic
+-- (ownership checks return 404). Pinning id = generate_series keeps each seeded
+-- identity stable across reseeds so e.g. `harry.evans.986` is always id 986.
+INSERT INTO user_service.users (id, username, email, password_hash, roles, created_at, updated_at)
+SELECT
+    generate_series as id,
     customer_seed_username(generate_series) as username,
     customer_seed_username(generate_series) || '@northbridge.example' as email,
     -- BCrypt hash for 'SimUser123!'
@@ -85,6 +94,10 @@ SELECT
     NOW() - (RANDOM() * INTERVAL '365 days') as created_at,
     NOW() - (RANDOM() * INTERVAL '90 days') as updated_at
 FROM generate_series(1, 1000);
+
+-- Advance the identity sequence past the pinned seed block so users registered at
+-- runtime never collide with (or get assigned into) a seeded id.
+SELECT setval(pg_get_serial_sequence('user_service.users', 'id'), 1000, true);
 
 -- Create accounts for simulation users with realistic balances
 INSERT INTO accounts_service.accounts (user_id, account_number, account_type, balance, created_at, updated_at)


### PR DESCRIPTION
## Problem
Full-stack traffic replay of the banking demo caps out because **seeded user identities aren't stable across reseeds**.

`V2__Seed_simulation_users.sql` inserts 1000 reusable customer users with `BIGSERIAL` and **no explicit id**. On a fresh DB they land on ids 1..1000 (so `harry.evans.986` = id 986), but any reseed reassigns them (it's now id 83697). Recorded traffic carries JWTs whose `userId` claim is the seeded id, and account ownership is keyed on that id — so once ids drift, the recorded JWTs go stale and replay fails ownership checks with **404s**.

Measured in a full-stack co-replay (gateway journey → real chain → fixture-restored DB): transaction POSTs went **0% → ~60%**; the residual failures are exactly these account-ownership 404s from stale seeded identities.

## Fix
Pin `id = generate_series` (1..1000) in the seed insert and `setval` the identity sequence past the seed block so:
- a given seed user keeps the same id across reseeds (recorded JWTs stay valid),
- runtime registrations never collide with a seeded id.

## Deploy note
This changes the `V2` checksum, so apply via a **clean reseed** (drop + recreate, re-running migrations) or `flyway repair` — not an incremental `migrate` on an already-seeded DB. A reseed also realigns seeded usernames to the current `customer_seed_username` scheme (the deployed DB still has the older `sim_user_<n>` names), which is what lets the simulation *reuse* seeded users instead of registering divergent ones.

## Validation status
Not yet validated end-to-end — needs a reseed of the demo DB + a fresh capture + re-replay. The full-stack replay already proves the mechanism (self-consistent flows pass); this removes the identity drift that caps the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)