### PR TITLE
Replay Lab: local reproduce/fix demo for the deposit memo bug

### DIFF
--- a/replay-lab-demo/.gitignore
+++ b/replay-lab-demo/.gitignore
@@ -1,0 +1,3 @@
+out/
+*.bak
+.replay/

--- a/replay-lab-demo/Makefile
+++ b/replay-lab-demo/Makefile
@@ -1,0 +1,38 @@
+# Replay Lab — local reproduce/fix loop for the banking deposit bug.
+#
+# proxymock replays a REAL captured production request against the service and mocks
+# every downstream dependency from REAL recorded traffic. Postgres is the only live
+# dependency (see setup.sh). Logic lives in the *.sh scripts so the commands work the
+# same by hand or under make.
+#
+#   Terminal 1:  make run         # service + proxymock mock (deps), bug armed
+#   Terminal 2:  make reproduce   # replay the captured prod failure  -> RED  (400)
+#                make fix         # apply the agent's fix, replay      -> GREEN (201)
+#
+SHELL := /bin/bash
+SVC   := backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
+PORT  ?= 8080
+export PORT
+
+.PHONY: help setup run reproduce fix reset down
+help: ## list targets
+	@grep -hE '^[a-z-]+:.*##' $(MAKEFILE_LIST) | sed 's/:.*##/\t/' | column -t -s "$$(printf '\t')"
+
+setup: ## one-time prereqs: postgres + db user + build (single script)
+	@./setup.sh
+
+run: ## terminal 1: proxymock mock (deps) + the service, bug armed
+	@./run.sh
+
+reproduce: ## terminal 2: replay the captured prod failure against the service
+	@./reproduce.sh
+
+fix: ## apply the agent's fix (fix.patch), hot-restart, replay -> GREEN
+	@./fix.sh
+
+reset: ## revert the fix (back to the bug)
+	@cd .. && git checkout -- $(SVC) && echo ">> reverted to the buggy version"
+
+down: ## stop the service + mock (leaves postgres up)
+	@pkill -f "spring-boot:run" 2>/dev/null; pkill -f "proxymock mock" 2>/dev/null; true
+	@echo "stopped (postgres left running; 'docker compose stop postgres' to stop it too)"

--- a/replay-lab-demo/README.md
+++ b/replay-lab-demo/README.md
@@ -1,0 +1,90 @@
+# Replay Lab — local reproduce → fix → validate loop
+
+This package reproduces a real production bug **on your laptop**, fixes it, and proves
+the fix — using a **captured production request** and Speedscale **proxymock** to mock
+every downstream dependency. No cluster, no staging, no hand-written test.
+
+It is the [Replay Lab](#where-the-replay-lab-fits) loop shrunk to a single service so you
+can watch every step.
+
+```
+ captured prod request ──▶  reproduce (RED)  ──▶  fix  ──▶  validate (GREEN)
+   real RRPair               replay → 400          patch       replay → 201
+                             deps mocked by proxymock
+```
+
+## The bug
+
+`transactions-service` normalizes a deposit's memo for a downstream ledger feed:
+
+```java
+String memo = request.getDescription().trim().toUpperCase();   // NPE when description is null
+```
+
+Real clients sometimes POST a deposit with **no `description`**. In production that throws a
+`NullPointerException`, the controller traces it and returns an error to the customer — the
+deposit silently fails. Observability shows you the exception; it does **not** hand you the
+exact request that triggered it. The captured RRPair does.
+
+The bug is gated behind `DEMO_MEMO_BUG_ENABLED` so it only arms for this demo.
+
+## Run it
+
+Prereqs: Docker (for Postgres), Java 17+, Maven, and `proxymock` (`~/.speedscale/proxymock`).
+
+```bash
+make setup        # one-time: start Postgres, create the service DB user, build the jar
+make run          # terminal 1: starts the service + proxymock mock (deps), bug armed
+make reproduce    # terminal 2: replays the captured prod failure   ->  RED   (HTTP 400)
+make fix          #             applies the agent's fix, hot-restarts ->  GREEN (HTTP 201)
+make reset        #             puts the bug back
+make down         # stop the service + mock
+```
+
+`make run` overrides the port with `PORT=…` if 8080 is taken (e.g. `make run PORT=8090`,
+`make reproduce PORT=8090`).
+
+## What is real vs mocked
+
+| Dependency | In this demo |
+|---|---|
+| **Postgres** | **real** — local container (`make setup`). JDBC ignores the HTTP proxy, so it stays live. |
+| accounts-service | **mocked** by proxymock from recorded traffic (`mocks/localhost/`) |
+| Stripe / PayPal / ComplyAdvantage | **mocked** by proxymock (`mocks/api.*`) — the deposit's payment/compliance fan-out |
+| fraud-service (gRPC) | absent → the client **fails open**, exactly as in production |
+
+The service talks to its dependencies through proxymock on `:4140`
+(`-Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140`). proxymock answers each outbound call
+with the **recorded** response, so the whole loop runs offline and deterministically.
+
+## What's in the box
+
+```
+captured/deposit-failure.md   the real captured production failure (POST /deposit, no description -> 400)
+mocks/localhost/*.md          recorded accounts-service responses (validate, get-balance, update-balance)
+mocks/api.*/*.md              recorded payment/compliance responses
+fix.patch                     the one-line null-guard fix (applied by `make fix`)
+setup.sh run.sh reproduce.sh fix.sh   the steps, as plain scripts (make just calls them)
+```
+
+The mocks were produced by recording one successful deposit against the real services:
+
+```bash
+proxymock record --app-port 8080 -- java -Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140 -jar <service>.jar
+# drive one good deposit through :4143, then reuse the recorded OUT pairs as mocks
+```
+
+Because they are real recordings (not hand-written), proxymock matches them by signature with
+no fix-ups.
+
+## Where the Replay Lab fits
+
+- **proxymock** is the **replay engine** — the thing you just ran on your laptop. It captures
+  traffic, mocks dependencies, and replays a request against your code.
+- **Replay Lab** is the **product** that runs this exact loop **continuously, in a cluster,
+  against live production traffic**: the forwarder streams captured traffic in, a work queue
+  picks failing requests, each one is replayed in an isolated runner (deps mocked, just like
+  here), and the result is bug evidence + release confidence — reproduce, fix, validate, repeat.
+
+This demo is that loop, by hand, on one bug: **capture → reproduce → fix → validate**. The
+Replay Lab is the same four steps, automated and always-on.

--- a/replay-lab-demo/captured/deposit-failure.md
+++ b/replay-lab-demo/captured/deposit-failure.md
@@ -1,0 +1,55 @@
+### REQUEST ###
+```
+POST http://localhost:8088/api/transactions/deposit HTTP/1.1
+Accept: */*
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Content-Type: application/json
+Host: localhost:8088
+User-Agent: curl/8.7.1
+```
+
+```
+{
+  "accountId": 70668,
+  "amount": 3.33
+}
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 400 Bad Request
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Date: Thu\, 25 Jun 2026 18:18:27 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is POST
+http:queryparams is -NONE-
+http:requestBodyJSON is {"accountId":70668,"amount":3.33}
+http:url is /api/transactions/deposit
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: ac47257d-9df8-4009-adaa-d9c15840767b
+ts: 2026-06-25T18:18:27.132643Z
+duration: 21ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=13, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:18:27.132643Z","l7protocol":"http","duration":21,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"13","source":"goproxy"},"uuid":"rEclfZ34QAmtqtnBWEB2ew==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","command":"POST","location":"/api/transactions/deposit","status":"400","http":{"req":{"url":"/api/transactions/deposit","uri":"/api/transactions/deposit","version":"1.1","method":"POST","host":"localhost:8088"},"res":{"statusCode":400,"statusMessage":"400 Bad Request"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UE9TVA==","http:queryparams":"","http:requestBodyJSON":"eyJhY2NvdW50SWQiOjcwNjY4LCJhbW91bnQiOjMuMzN9","http:url":"L2FwaS90cmFuc2FjdGlvbnMvZGVwb3NpdA=="},"netinfo":{"id":"5","startTime":"2026-06-25T18:18:27.132578Z","downstream":{"established":"2026-06-25T18:18:27.132042Z","ipAddress":"127.0.0.1","port":64190,"bytesSent":"386"},"upstream":{"established":"2026-06-25T18:18:27.132503Z","ipAddress":"127.0.0.1","port":8088,"hostname":"localhost","bytesSent":"351"}}}
+```

--- a/replay-lab-demo/fix.patch
+++ b/replay-lab-demo/fix.patch
@@ -1,0 +1,13 @@
+diff --git a/backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java b/backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
+index 4368c81..a58f7f5 100644
+--- a/backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
++++ b/backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
+@@ -106,7 +106,7 @@ public class TransactionService {
+ 
+         if (memoBugEnabled) {
+             // Normalize the transaction memo for the downstream ledger feed.
+-            String memo = request.getDescription().trim().toUpperCase();
++            String memo = request.getDescription() == null ? "" : request.getDescription().trim().toUpperCase();
+             logger.debug("Normalized ledger memo ({} chars) for account {}", memo.length(), request.getAccountId());
+         }
+ 

--- a/replay-lab-demo/fix.sh
+++ b/replay-lab-demo/fix.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Apply the agent's fix (fix.patch), let spring-boot devtools hot-restart the running
+# service, then replay the same captured failure to prove it is GREEN.
+set -euo pipefail
+cd "$(dirname "$0")"
+DEMO="$PWD"
+ROOT="$(cd .. && pwd)"
+TX="$ROOT/backend/transactions-service"
+
+echo ">> applying fix.patch"
+( cd "$ROOT" && git apply "$DEMO/fix.patch" && git --no-pager diff --stat \
+    backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java )
+
+echo ">> recompiling (spring-boot devtools hot-restarts the running service)"
+( cd "$TX" && mvn -q -o compile )
+
+echo ">> waiting for hot-restart..."
+sleep 10
+PORT="${PORT:-8080}" ./reproduce.sh

--- a/replay-lab-demo/mocks/api-m.sandbox.paypal.com/2026-06-25_18-26-03.142565Z.md
+++ b/replay-lab-demo/mocks/api-m.sandbox.paypal.com/2026-06-25_18-26-03.142565Z.md
@@ -1,0 +1,75 @@
+### REQUEST ###
+```
+POST https://api-m.sandbox.paypal.com:443/v2/checkout/orders HTTP/2.0
+Authorization: Bearer A21AAJ_dummy_paypal_token_for_ebpf
+Content-Type: application/json
+Host: api-m.sandbox.paypal.com
+User-Agent: Java-http-client/17.0.19
+```
+
+```
+{
+  "intent": "CAPTURE",
+  "purchase_units": [
+    {
+      "amount": {
+        "currency_code": "USD",
+        "value": "3.33"
+      }
+    }
+  ]
+}
+```
+
+### RESPONSE ###
+```
+HTTP/2.0 401 Unauthorized
+Accept-Ranges: bytes
+Access-Control-Expose-Headers: Server-Timing
+Cache-Control: max-age=0\, no-cache\, no-store\, must-revalidate
+Content-Type: application/json
+Date: Thu\, 25 Jun 2026 18:26:03 GMT
+Edge-Control: max-age=0
+Http_x_pp_az_locator: ccg18.slc
+Paypal-Debug-Id: f808687d2ccc8
+Server: nginx
+Server-Timing: traceparent;desc="00-0000000000000000000f808687d2ccc8-52b146df2aa2ac1a-01"
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+Vary: Accept-Encoding
+Via: 1.1 varnish\, 1.1 varnish
+X-Backend-Info: v=1;name=2k1u3gOGb2cebCyZJujTUN--F_ccg18_wju_origin_api_m_1_sandbox_paypal_com;ip=34.106.238.133;port=443;ssl=1;max=200;mr=0;ka_ns=0;ml_ns=0;tka_s=300;tki_s=10;tkp=3;host=api-m.sandbox.paypal.com;min_tls=;max_tls=;sni=edge.sandbox.paypal.com;cert_host=edge.sandbox.paypal.com;ciphers=;check_cert=1;no_reneg=1;to_ns=1000000000;fbto_ns=59000000000;bbto_ns=10000000000;fto_ns=0
+X-Cache: MISS\, MISS\, MISS
+X-Cache-Hits: 0\, 0\, 0
+X-Served-By: cache-iad-kiad7000169-IAD\, cache-iad-kiad7000107-IAD\, cache-jax2030034-JAX
+X-Timer: S1782411963.656634\,VS0\,VE510
+```
+
+```
+{
+  "error": "invalid_token",
+  "error_description": "The token passed in was not found in the system"
+}
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is POST
+http:queryparams is -NONE-
+http:requestBodyJSON is {"intent":"CAPTURE","purchase_units":[{"amount":{"currency_code":"USD","value":"3.33"}}]}
+http:url is /v2/checkout/orders
+```
+
+### METADATA ###
+```
+direction: OUT
+uuid: 7ef4f09b-9ccc-4f85-99d5-86b36d574765
+ts: 2026-06-25T18:26:03.142565Z
+duration: 1ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=11, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:26:03.142565Z","isTls":true,"l7protocol":"https","duration":1,"alpn":"h2","tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"out","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"11","source":"goproxy"},"uuid":"fvTwm5zMT4WZ1YazbVdHZQ==","direction":"OUT","cluster":"undefined","namespace":"undefined","service":"my-app","command":"POST","location":"/v2/checkout/orders","status":"401","http":{"req":{"url":"/v2/checkout/orders","uri":"/v2/checkout/orders","version":"2.0","method":"POST","host":"api-m.sandbox.paypal.com"},"res":{"contentType":"application/json","statusCode":401,"statusMessage":"401 Unauthorized"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UE9TVA==","http:queryparams":"","http:requestBodyJSON":"eyJpbnRlbnQiOiJDQVBUVVJFIiwicHVyY2hhc2VfdW5pdHMiOlt7ImFtb3VudCI6eyJjdXJyZW5jeV9jb2RlIjoiVVNEIiwidmFsdWUiOiIzLjMzIn19XX0=","http:url":"L3YyL2NoZWNrb3V0L29yZGVycw=="},"netinfo":{"id":"3","startTime":"2026-06-25T18:26:02.593975Z","downstream":{"established":"2026-06-25T18:26:02.410293Z","ipAddress":"127.0.0.1","port":64953,"bytesSent":"309"},"upstream":{"established":"2026-06-25T18:26:02.526334Z","ipAddress":"151.101.3.1","port":443,"hostname":"api-m.sandbox.paypal.com","bytesSent":"899"}}}
+```

--- a/replay-lab-demo/mocks/api.complyadvantage.com/2026-06-25_18-26-03.055306Z.md
+++ b/replay-lab-demo/mocks/api.complyadvantage.com/2026-06-25_18-26-03.055306Z.md
@@ -1,0 +1,69 @@
+### REQUEST ###
+```
+POST https://api.complyadvantage.com:443/searches HTTP/2.0
+Authorization: Token comply_test_dummy_key_for_ebpf
+Content-Type: application/json
+Host: api.complyadvantage.com
+User-Agent: Java-http-client/17.0.19
+```
+
+```
+{
+  "search_term": "Transaction 17",
+  "search_type": "individual",
+  "fuzziness": 0.6
+}
+```
+
+### RESPONSE ###
+```
+HTTP/2.0 401 Unauthorized
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Cross-Origin-Opener-Policy: same-origin
+Date: Thu\, 25 Jun 2026 18:26:03 GMT
+Expires: Thur 1\, Jan 1970 00:00:00 UTC
+Pragma: no-cache
+Referrer-Policy: strict-origin-when-cross-origin
+Request-Id: d8un5ep0ppac73939530
+Served-By: arpeggio
+Server: complyadvantage
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+Www-Authenticate: Token realm="arpeggio"
+X-Amzn-Trace-Id: Root=1-6a3d72bb-22e594676b8928bd711dcbca
+X-Content-Type-Options: nosniff
+X-Dns-Prefetch-Control: off
+X-Envoy-Upstream-Service-Time: 2
+X-Permitted-Cross-Domain-Policies: none
+X-Robots-Tag: none
+X-Xss-Protection: 1; mode=block
+```
+
+```
+{
+  "message": "API Key is invalid or was not provided"
+}
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is POST
+http:queryparams is -NONE-
+http:requestBodyJSON is {"fuzziness":0.6,"search_term":"Transaction 17","search_type":"individual"}
+http:url is /searches
+```
+
+### METADATA ###
+```
+direction: OUT
+uuid: 53ec5851-2ba3-4e46-be44-f7606127fd0c
+ts: 2026-06-25T18:26:03.055306Z
+duration: 1ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=9, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:26:03.055306Z","isTls":true,"l7protocol":"https","duration":1,"alpn":"h2","tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"out","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"9","source":"goproxy"},"uuid":"U+xYUSujTka+RPdgYSf9DA==","direction":"OUT","cluster":"undefined","namespace":"undefined","service":"my-app","command":"POST","location":"/searches","status":"401","http":{"req":{"url":"/searches","uri":"/searches","version":"2.0","method":"POST","host":"api.complyadvantage.com"},"res":{"contentType":"application/json","statusCode":401,"statusMessage":"401 Unauthorized"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UE9TVA==","http:queryparams":"","http:requestBodyJSON":"eyJmdXp6aW5lc3MiOjAuNiwic2VhcmNoX3Rlcm0iOiJUcmFuc2FjdGlvbiAxNyIsInNlYXJjaF90eXBlIjoiaW5kaXZpZHVhbCJ9","http:url":"L3NlYXJjaGVz"},"netinfo":{"id":"4","startTime":"2026-06-25T18:26:02.936382Z","downstream":{"established":"2026-06-25T18:26:02.410287Z","ipAddress":"127.0.0.1","port":64955,"bytesSent":"283"},"upstream":{"established":"2026-06-25T18:26:02.624106Z","ipAddress":"18.202.116.64","port":443,"hostname":"api.complyadvantage.com","bytesSent":"657"}}}
+```

--- a/replay-lab-demo/mocks/api.stripe.com/2026-06-25_18-26-02.640049Z.md
+++ b/replay-lab-demo/mocks/api.stripe.com/2026-06-25_18-26-02.640049Z.md
@@ -1,0 +1,69 @@
+### REQUEST ###
+```
+POST https://api.stripe.com:443/v1/payment_intents HTTP/2.0
+Authorization: Bearer sk_test_dummy_key_for_ebpf_capture
+Content-Type: application/x-www-form-urlencoded
+Host: api.stripe.com
+User-Agent: Java-http-client/17.0.19
+```
+
+```
+{
+  "amount": "3",
+  "currency": "usd",
+  "payment_method_types[]": "card"
+}
+```
+
+### RESPONSE ###
+```
+HTTP/2.0 401 Unauthorized
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET\, HEAD\, PUT\, PATCH\, POST\, DELETE
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Request-Id\, Stripe-Manage-Version\, Stripe-Should-Retry\, X-Stripe-External-Auth-Required\, X-Stripe-Privileged-Session-Required
+Access-Control-Max-Age: 300
+Cache-Control: no-cache\, no-store
+Content-Security-Policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests
+Content-Type: application/json
+Date: Thu\, 25 Jun 2026 18:26:02 GMT
+Server: nginx
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Vary: Origin
+Www-Authenticate: Bearer realm="Stripe"
+X-Robots-Tag: none
+X-Wc: 383
+```
+
+```
+{
+  "error": {
+    "message": "Invalid API Key provided: sk_test_**********************ture",
+    "type": "invalid_request_error"
+  }
+}
+
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is POST
+http:queryparams is -NONE-
+http:requestBodyJSON is {"amount":"3","currency":"usd","payment_method_types[]":"card"}
+http:url is /v1/payment_intents
+```
+
+### METADATA ###
+```
+direction: OUT
+uuid: b9747515-3c0b-4ba3-9adb-60ebe3db0666
+ts: 2026-06-25T18:26:02.640049Z
+duration: 1ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=7, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:26:02.640049Z","isTls":true,"l7protocol":"https","duration":1,"alpn":"h2","tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"out","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"7","source":"goproxy"},"uuid":"uXR1FTwLS6Oa22Dr49sGZg==","direction":"OUT","cluster":"undefined","namespace":"undefined","service":"my-app","command":"POST","location":"/v1/payment_intents","status":"401","http":{"req":{"url":"/v1/payment_intents","uri":"/v1/payment_intents","version":"2.0","method":"POST","host":"api.stripe.com"},"res":{"contentType":"application/json","statusCode":401,"statusMessage":"401 Unauthorized"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UE9TVA==","http:queryparams":"","http:requestBodyJSON":"eyJhbW91bnQiOiIzIiwiY3VycmVuY3kiOiJ1c2QiLCJwYXltZW50X21ldGhvZF90eXBlc1tdIjoiY2FyZCJ9","http:url":"L3YxL3BheW1lbnRfaW50ZW50cw=="},"netinfo":{"id":"2","startTime":"2026-06-25T18:26:02.619326Z","downstream":{"established":"2026-06-25T18:26:02.410281Z","ipAddress":"127.0.0.1","port":64954,"bytesSent":"274"},"upstream":{"established":"2026-06-25T18:26:02.474073Z","ipAddress":"198.137.150.101","port":443,"hostname":"api.stripe.com","bytesSent":"743"}}}
+```

--- a/replay-lab-demo/mocks/localhost/2026-06-25_18-26-02.244952Z.md
+++ b/replay-lab-demo/mocks/localhost/2026-06-25_18-26-02.244952Z.md
@@ -1,0 +1,60 @@
+### REQUEST ###
+```
+GET http://localhost:8082/api/accounts/70668 HTTP/1.1
+Accept: application/json\, application/*+json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Host: localhost:8082
+Proxy-Connection: keep-alive
+User-Agent: Java/17.0.19
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Date: Thu\, 25 Jun 2026 18:26:02 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "id": 70668,
+  "userId": 1,
+  "accountNumber": "0000000070668",
+  "balance": 1000.00,
+  "accountType": "CHECKING",
+  "createdAt": "2026-06-25T18:10:40.503001",
+  "updatedAt": "2026-06-25T18:18:25.95814"
+}
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is GET
+http:queryparams is -NONE-
+http:url is /api/accounts/70668
+```
+
+### METADATA ###
+```
+direction: OUT
+uuid: fbde96fa-416c-417e-b56c-efd3ff296d08
+ts: 2026-06-25T18:26:02.244952Z
+duration: 1ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=2, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:26:02.244952Z","l7protocol":"http","duration":1,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"out","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"2","source":"goproxy"},"uuid":"+96W+kFsQX61bO/T/yltCA==","direction":"OUT","cluster":"undefined","namespace":"undefined","service":"my-app","command":"GET","location":"/api/accounts/70668","status":"200","http":{"req":{"url":"/api/accounts/70668","uri":"/api/accounts/70668","version":"1.1","method":"GET","host":"localhost:8082"},"res":{"contentType":"application/json","statusCode":200,"statusMessage":"200 OK"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"R0VU","http:queryparams":"","http:url":"L2FwaS9hY2NvdW50cy83MDY2OA=="},"netinfo":{"id":"2","startTime":"2026-06-25T18:26:02.138856Z","downstream":{"established":"2026-06-25T18:26:02.138856Z","ipAddress":"127.0.0.1","port":64946},"upstream":{"established":"2026-06-25T18:26:02.139256Z","port":8082,"hostname":"localhost","bytesSent":"18446744073709551615"}}}
+```

--- a/replay-lab-demo/mocks/localhost/2026-06-25_18-26-02.26794Z.md
+++ b/replay-lab-demo/mocks/localhost/2026-06-25_18-26-02.26794Z.md
@@ -1,0 +1,56 @@
+### REQUEST ###
+```
+GET http://localhost:8082/api/accounts/70668/balance HTTP/1.1
+Accept: application/json\, application/*+json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Host: localhost:8082
+Proxy-Connection: keep-alive
+User-Agent: Java/17.0.19
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Date: Thu\, 25 Jun 2026 18:26:02 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "accountId": 70668,
+  "accountNumber": "0000000070668",
+  "balance": 1000.00
+}
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is GET
+http:queryparams is -NONE-
+http:url is /api/accounts/70668/balance
+```
+
+### METADATA ###
+```
+direction: OUT
+uuid: 41b31ea9-b8ee-481b-851c-4ae91300bef9
+ts: 2026-06-25T18:26:02.26794Z
+duration: 1ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=3, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:26:02.267940Z","l7protocol":"http","duration":1,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"out","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"3","source":"goproxy"},"uuid":"QbMeqbjuSBuFHErpEwC++Q==","direction":"OUT","cluster":"undefined","namespace":"undefined","service":"my-app","command":"GET","location":"/api/accounts/70668/balance","status":"200","http":{"req":{"url":"/api/accounts/70668/balance","uri":"/api/accounts/70668/balance","version":"1.1","method":"GET","host":"localhost:8082"},"res":{"contentType":"application/json","statusCode":200,"statusMessage":"200 OK"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"R0VU","http:queryparams":"","http:url":"L2FwaS9hY2NvdW50cy83MDY2OC9iYWxhbmNl"},"netinfo":{"id":"3","startTime":"2026-06-25T18:26:02.248598Z","downstream":{"established":"2026-06-25T18:26:02.248598Z","ipAddress":"127.0.0.1","port":64949},"upstream":{"established":"2026-06-25T18:26:02.248711Z","port":8082,"hostname":"localhost","bytesSent":"18446744073709551615"}}}
+```

--- a/replay-lab-demo/mocks/localhost/2026-06-25_18-26-02.307187Z.md
+++ b/replay-lab-demo/mocks/localhost/2026-06-25_18-26-02.307187Z.md
@@ -1,0 +1,55 @@
+### REQUEST ###
+```
+PUT http://localhost:8082/api/accounts/70668/balance HTTP/1.1
+Accept: application/json\, application/*+json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Content-Type: application/json
+Host: localhost:8082
+Proxy-Connection: keep-alive
+User-Agent: Java/17.0.19
+```
+
+```
+{
+  "balance": 1003.33
+}
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Date: Thu\, 25 Jun 2026 18:26:02 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is PUT
+http:queryparams is -NONE-
+http:requestBodyJSON is {"balance":1003.33}
+http:url is /api/accounts/70668/balance
+```
+
+### METADATA ###
+```
+direction: OUT
+uuid: 83a7dd0b-db31-4d42-bf51-c5fb850a05b6
+ts: 2026-06-25T18:26:02.307187Z
+duration: 1ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.683, reverseProxyHost=localhost, reverseProxyPort=8088, sequence=4, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-06-25T18:26:02.307187Z","l7protocol":"http","duration":1,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"out","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.683","reverseProxyHost":"localhost","reverseProxyPort":"8088","sequence":"4","source":"goproxy"},"uuid":"g6fdC9sxTUK/UcX7hQoFtg==","direction":"OUT","cluster":"undefined","namespace":"undefined","service":"my-app","command":"PUT","location":"/api/accounts/70668/balance","status":"200","http":{"req":{"url":"/api/accounts/70668/balance","uri":"/api/accounts/70668/balance","version":"1.1","method":"PUT","host":"localhost:8082"},"res":{"statusCode":200,"statusMessage":"200 OK"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UFVU","http:queryparams":"","http:requestBodyJSON":"eyJiYWxhbmNlIjoxMDAzLjMzfQ==","http:url":"L2FwaS9hY2NvdW50cy83MDY2OC9iYWxhbmNl"},"netinfo":{"id":"4","startTime":"2026-06-25T18:26:02.276871Z","downstream":{"established":"2026-06-25T18:26:02.276871Z","ipAddress":"127.0.0.1","port":64950,"bytesSent":"19"},"upstream":{"established":"2026-06-25T18:26:02.278837Z","port":8082,"hostname":"localhost"}}}
+```

--- a/replay-lab-demo/reproduce.sh
+++ b/replay-lab-demo/reproduce.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Replay the captured production failure against the local service and report the result.
+set -euo pipefail
+cd "$(dirname "$0")"
+PM="$HOME/.speedscale/proxymock"
+PORT="${PORT:-8080}"
+
+rm -rf out
+"$PM" replay --in captured --test-against "http://localhost:$PORT" --out out >/dev/null 2>&1 || true
+code=$(grep -rohE '"statusCode":[0-9]+' out 2>/dev/null | grep -oE '[0-9]+' | head -1)
+
+echo
+case "$code" in
+  400) echo "  RED   — the captured deposit reproduces the production failure (HTTP 400)";;
+  201) echo "  GREEN — the captured deposit now succeeds (HTTP 201) — bug fixed";;
+  "")  echo "  no response — is 'make run' up in terminal 1?";;
+  *)   echo "  replay returned HTTP $code";;
+esac
+echo

--- a/replay-lab-demo/run.sh
+++ b/replay-lab-demo/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Terminal 1: start proxymock mock (serves every downstream dependency from recorded
+# traffic) and the transactions-service (deps mocked, bug armed). Ctrl-C stops both.
+set -euo pipefail
+cd "$(dirname "$0")"
+DEMO="$PWD"
+ROOT="$(cd .. && pwd)"
+TX="$ROOT/backend/transactions-service"
+PM="$HOME/.speedscale/proxymock"
+PORT="${PORT:-8080}"
+JWT='banking-app-super-secret-key-change-this-in-production-256-bit'
+
+# proxymock mock: app -> proxy :4140 -> recorded response (accounts, stripe, paypal, complyadvantage)
+"$PM" mock --in mocks --no-out >/tmp/replay-lab-mock.log 2>&1 &
+MOCK_PID=$!
+trap 'kill $MOCK_PID 2>/dev/null || true' EXIT
+echo ">> proxymock mock serving deps on :4140  (accounts, stripe, paypal, complyadvantage)"
+echo ">> starting transactions-service on :$PORT  (deps mocked, bug armed)"
+echo
+
+cd "$TX"
+# RestTemplate (HttpURLConnection) honors -Dhttp.proxy* -> outbound accounts calls hit proxymock.
+# Postgres (JDBC) ignores the HTTP proxy and stays a real local dependency.
+exec env \
+  DB_HOST=localhost DB_PORT=5432 DB_NAME=banking_app \
+  DB_USERNAME=transactions_service_user DB_PASSWORD=transactions_service_pass DB_SCHEMA=transactions_service \
+  JWT_SECRET="$JWT" ACCOUNTS_SERVICE_URL=http://localhost:8082 \
+  FRAUD_SERVICE_HOST=localhost FRAUD_SERVICE_PORT=9999 \
+  OTEL_SDK_DISABLED=true DEMO_MEMO_BUG_ENABLED=true SERVER_PORT="$PORT" \
+  mvn -q -o spring-boot:run \
+    -Dspring-boot.run.jvmArguments="-Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140 -Dhttp.nonProxyHosts= -Dspring.kafka.producer.properties.max.block.ms=1500"

--- a/replay-lab-demo/setup.sh
+++ b/replay-lab-demo/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Single prerequisite script for the Replay Lab local demo.
+# Brings up the one real dependency (Postgres) and builds the service.
+# Everything else (the accounts dependency) is mocked by proxymock — see the Makefile.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"   # microsvc repo root
+cd "$ROOT"
+
+echo "[1/3] Postgres — the only real dependency transactions-service needs to boot"
+docker compose up -d postgres
+echo -n "      waiting for postgres "
+until docker exec banking-postgres pg_isready -U postgres >/dev/null 2>&1; do echo -n .; sleep 1; done
+echo " ready"
+
+echo "[2/3] Service DB user + grants"
+docker exec banking-postgres psql -U postgres -d banking_app -q <<'SQL'
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='transactions_service_user') THEN
+    CREATE USER transactions_service_user WITH PASSWORD 'transactions_service_pass';
+  END IF;
+END $$;
+GRANT ALL ON SCHEMA transactions_service TO transactions_service_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA transactions_service GRANT ALL ON TABLES TO transactions_service_user;
+SQL
+
+echo "[3/3] Build transactions-service"
+( cd backend/transactions-service && mvn -q -o -DskipTests package 2>/dev/null || mvn -q -DskipTests package )
+
+echo
+echo "Done. Now (in this dir):"
+echo "  make run         # terminal 1: start the service (bug armed)"
+echo "  make reproduce   # terminal 2: replay the captured prod failure -> 400 (red)"
+echo "  make fix         # apply the agent's null-guard fix; replay -> 201 (green)"


### PR DESCRIPTION
# Problem
We need a runnable artifact for the Replay Lab flagship video: reproduce a real production bug **on a laptop**, fix it, and prove the fix — without a cluster, staging, or a hand-written test.

# Solution
`replay-lab-demo/` packages the loop end to end against `transactions-service`:

- **captured/** — the real captured failing deposit (`POST /deposit` with no `description` → memo `NullPointerException` → 400).
- **mocks/** — recorded `accounts-service` + payment/compliance (Stripe/PayPal/ComplyAdvantage) responses, served by **proxymock** (`http_proxy` → `:4140`). Postgres is the only live dependency; fraud-service fails open as in prod.
- **fix.patch** — the one-line null-guard fix.
- **Makefile + setup.sh/run.sh/reproduce.sh/fix.sh** — `make setup | run | reproduce | fix | reset | down`. Logic lives in plain scripts so the commands work the same by hand or under make.

The README explains what's real vs mocked, how the mocks were recorded, and **where the Replay Lab product fits** (proxymock = the replay engine; Replay Lab = the same capture→reproduce→fix→validate loop, automated and always-on against live traffic).

Verified end to end on this branch: `make reproduce` → RED (HTTP 400), `make fix` → hot-restart → GREEN (HTTP 201). The bug stays gated behind `DEMO_MEMO_BUG_ENABLED`; no production code path changes.

## Checklist
Each of these checkboxes should be filled before merge.
- [x] Demo loop verified locally (reproduce → RED, fix → GREEN)
- [x] Mocks are real recordings (proxymock matches by signature, no fix-ups)
- [x] No secrets committed (compliance keys are the app's dummy placeholders)
- [x] No production code path changed (bug is flag-gated, demo lives under replay-lab-demo/)