### PR TITLE
Align OTEL config for meshed banking demo

### DIFF
--- a/backend/ai-service/main.py
+++ b/backend/ai-service/main.py
@@ -29,7 +29,14 @@ logger = logging.getLogger(__name__)
 # :4318 — same as the frontend Node service uses).
 _otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.observability:4318")
 _otel_service_name = os.environ.get("OTEL_SERVICE_NAME", "ai-service")
-_tracer_provider = TracerProvider(resource=Resource.create({"service.name": _otel_service_name, "service.namespace": "banking-app"}))
+_otel_resource_attributes = {
+    key.strip(): value.strip()
+    for item in os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=banking-app").split(",")
+    if "=" in item
+    for key, value in [item.split("=", 1)]
+}
+_otel_resource_attributes["service.name"] = _otel_service_name
+_tracer_provider = TracerProvider(resource=Resource.create(_otel_resource_attributes))
 _tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{_otel_endpoint.rstrip('/')}/v1/traces")))
 trace.set_tracer_provider(_tracer_provider)
 HTTPXClientInstrumentor().instrument()

--- a/backend/transactions-service/src/main/resources/application.yml
+++ b/backend/transactions-service/src/main/resources/application.yml
@@ -99,7 +99,7 @@ otel:
   exporter:
     otlp:
       protocol: grpc
-      endpoint: http://localhost:4317
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}
   traces:
     exporter: otlp
     propagators: tracecontext

--- a/frontend/src/instrumentation.ts
+++ b/frontend/src/instrumentation.ts
@@ -18,6 +18,17 @@ function log(message: string, ...args: unknown[]) {
   }
 }
 
+function resourceAttribute(name: string, fallback: string): string {
+  const attributes = process.env.OTEL_RESOURCE_ATTRIBUTES || '';
+  for (const item of attributes.split(',')) {
+    const [key, ...valueParts] = item.split('=');
+    if (key?.trim() === name) {
+      return valueParts.join('=').trim() || fallback;
+    }
+  }
+  return fallback;
+}
+
 // Register the SDK - only runs on the server side
 export async function register() {
   // Only initialize on server side to avoid bundling issues with browser
@@ -72,7 +83,8 @@ export async function register() {
       resource: new Resource({
         [SemanticResourceAttributes.SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || 'frontend',
         [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
-        [SemanticResourceAttributes.SERVICE_NAMESPACE]: process.env.OTEL_RESOURCE_ATTRIBUTES?.split('=')[1] || 'banking-app',
+        [SemanticResourceAttributes.SERVICE_NAMESPACE]: resourceAttribute('service.namespace', 'banking-app'),
+        'deployment.environment': resourceAttribute('deployment.environment', 'decoy'),
       }),
     });
 
@@ -126,7 +138,7 @@ export async function register() {
 
     log('✅ OpenTelemetry instrumentation registered successfully for frontend server');
     log('🔧 Service name:', process.env.OTEL_SERVICE_NAME || 'frontend');
-    log('🔧 Service namespace:', process.env.OTEL_RESOURCE_ATTRIBUTES?.split('=')[1] || 'banking-app');
+    log('🔧 Service namespace:', resourceAttribute('service.namespace', 'banking-app'));
 
     // Gracefully shutdown the tracer provider on process exit
     process.on('SIGTERM', () => {

--- a/kubernetes/base/configmaps/app-config.yaml
+++ b/kubernetes/base/configmaps/app-config.yaml
@@ -37,7 +37,7 @@ data:
   OTEL_LOGS_EXPORTER: "otlp"
   OTEL_TRACES_SAMPLER: "always_on"
   OTEL_PROPAGATORS: "tracecontext"
-  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app"
+  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app,deployment.environment=decoy"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -175,7 +175,7 @@ data:
   OTEL_LOGS_EXPORTER: "otlp"
   OTEL_TRACES_SAMPLER: "always_on"
   OTEL_PROPAGATORS: "tracecontext"
-  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app"
+  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app,deployment.environment=decoy"
   
   # Next.js configuration
   NODE_ENV: "production"
@@ -202,4 +202,4 @@ data:
   OTEL_LOGS_EXPORTER: "none"
   OTEL_TRACES_SAMPLER: "always_on"
   OTEL_PROPAGATORS: "tracecontext"
-  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app"
+  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app,deployment.environment=decoy"

--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -65,7 +65,7 @@ data:
   OTEL_LOGS_EXPORTER: "otlp"
   OTEL_TRACES_SAMPLER: "always_on"
   OTEL_PROPAGATORS: "tracecontext"
-  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app"
+  OTEL_RESOURCE_ATTRIBUTES: "service.namespace=banking-app,deployment.environment=decoy"
 
   # Metrics reporting
   METRICS_INTERVAL: "30000"

--- a/kubernetes/base/deployments/fraud-service-deployment.yaml
+++ b/kubernetes/base/deployments/fraud-service-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: "8080"
         - name: METRICS_PORT
           value: "9091"
+        - name: OTEL_SERVICE_NAME
+          value: "fraud-service"
         envFrom:
         - configMapRef:
             name: app-config

--- a/kubernetes/base/deployments/notification-service-deployment.yaml
+++ b/kubernetes/base/deployments/notification-service-deployment.yaml
@@ -43,6 +43,8 @@ spec:
           value: "8080"
         - name: MONGO_URI
           value: "mongodb://banking-mongodb:27017"
+        - name: OTEL_SERVICE_NAME
+          value: "notification-service"
         envFrom:
         - configMapRef:
             name: app-config

--- a/kubernetes/overlays/replay/kustomization.yaml
+++ b/kubernetes/overlays/replay/kustomization.yaml
@@ -58,6 +58,9 @@ patches:
       - op: replace
         path: /metadata/labels/app.kubernetes.io~1name
         value: banking-app-replay
+      - op: add
+        path: /metadata/labels/istio-injection
+        value: enabled
   - patch: |-
       apiVersion: v1
       kind: ConfigMap

--- a/kubernetes/overlays/speedscale/kustomization.yaml
+++ b/kubernetes/overlays/speedscale/kustomization.yaml
@@ -32,6 +32,9 @@ patches:
     - op: add
       path: /metadata/labels/speedscale
       value: "true"
+    - op: add
+      path: /metadata/labels/istio-injection
+      value: enabled
 - path: user-service-annotations.yaml
 - path: accounts-service-annotations.yaml
 - path: transactions-service-annotations.yaml


### PR DESCRIPTION
## Summary

- Enable Istio injection on the banking app and replay namespaces.
- Normalize OTEL resource attributes across app runtimes with `service.namespace=banking-app` and `deployment.environment=decoy`.
- Give fraud and notification explicit `OTEL_SERVICE_NAME` values.
- Fix transactions-service to honor `OTEL_EXPORTER_OTLP_ENDPOINT` instead of a hardcoded localhost collector.
- Make the Python and Next.js instrumentation parse the shared `OTEL_RESOURCE_ATTRIBUTES` format.

Linear: https://linear.app/speedscale/issue/S-12070/add-istio-service-mesh-to-the-banking-demo-capture-replay-meshed

## Validation

- `git diff --check`
- `kubectl kustomize kubernetes/overlays/speedscale`
- `kubectl kustomize kubernetes/overlays/replay`
- `kubectl kustomize kubernetes/overlays/speedscale-sidecar`
- `python3 -c 'from pathlib import Path; p=Path("backend/ai-service/main.py"); compile(p.read_text(), str(p), "exec"); print("python syntax ok")'`

`npm --prefix frontend run lint` could not run in the fresh worktree because dependencies are not installed (`next: command not found`).