### PR TITLE
Fix staging replay Argo sync

### DIFF
--- a/kubernetes/overlays/replay/kustomization.yaml
+++ b/kubernetes/overlays/replay/kustomization.yaml
@@ -44,6 +44,21 @@ patches:
         name: banking-sim-secret
         namespace: banking-app
       $patch: delete
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: banking-frontend-nodeport
+        namespace: banking-app
+      $patch: delete
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: banking-fraud
+        namespace: banking-app
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
   - target:
       version: v1
       kind: Namespace


### PR DESCRIPTION
## Summary
- remove the shared frontend NodePort service from the replay overlay
- make Argo replace the replay fraud Deployment to avoid stale client-side apply port-list merges

## Verification
- ./thoughts/scripts/verify-replay-kustomize.sh
- kubectl --context do-nyc1-staging-decoy replace --dry-run=server -f /tmp/microsvc-replay-fraud-deploy.yaml

Refs S-12070