### PR TITLE
Cover banking workloads with Istio injection

### DIFF
--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -63,3 +63,33 @@ labels:
     app.kubernetes.io/name: banking-app
     app.kubernetes.io/version: v1.0.0
     app.kubernetes.io/managed-by: kustomize
+
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ignored
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "true"
+- target:
+    group: batch
+    version: v1
+    kind: Job
+  patch: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ignored
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "true"

--- a/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
+++ b/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
@@ -61,6 +61,9 @@ spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 2
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: speedscale-postsync-reroll
       restartPolicy: Never


### PR DESCRIPTION
## Summary
- add explicit Istio sidecar injection to all base banking Deployment and Job templates
- add injection to the banking-app speedscale PostSync reroll Job
- keeps namespace injection labels, but no longer relies on old pods rolling by chance

## Verification
- rendered kubernetes/overlays/speedscale
- rendered kubernetes/overlays/replay
- verified every Deployment and Job template in banking-app and banking-replay has sidecar.istio.io/inject: "true"

Refs S-12070