### PR TITLE
Update banking-mock-fail-closed to the API field names

### DIFF
--- a/kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
+++ b/kubernetes/overlays/speedscale/responders/banking-mock-fail-closed.json
@@ -1,27 +1,28 @@
 {
-    "id": "banking-mock-fail-closed",
-    "generator": {
-        "stages": [
-            {
-                "virtualUsers": {
-                    "virtualUsers": "1",
-                    "requestDelay": {}
-                }
-            }
-        ]
-    },
-    "rules": [],
-    "version": 3,
-    "assertionGroups": [],
-    "responder": {
-        "numReplicas": 1,
-        "passthrough_mode": false
-    },
-    "cluster": {
-        "replayMode": "responder-only",
-        "logsCollected": false,
-        "sidecar_tls_out": true,
-        "cleanup": "inventory",
-        "logLevel": "info"
+  "cluster": {
+    "cleanup": "inventory",
+    "logLevel": "info",
+    "logsCollected": false,
+    "replayMode": "responder-only",
+    "sidecarTlsOut": true
+  },
+  "generator": {
+    "evaluationIntervals": 5,
+    "stages": [
+      {
+        "virtualUsers": {
+          "requestDelay": {},
+          "virtualUsers": "1"
+        }
+      }
+    ]
+  },
+  "id": "banking-mock-fail-closed",
+  "responder": {
+    "numReplicas": 1,
+    "responseDelay": {
+      "mode": "RECORDED"
     }
+  },
+  "version": 3
 }


### PR DESCRIPTION
Pushing the repo copy of `banking-mock-fail-closed.json` per the responders README produced a broken config: its snake_case keys (`sidecar_tls_out`, `passthrough_mode`) are silently ignored by the test-config API, so `sidecarTlsOut` came out unset and the operator never injected the `speedscale-goproxy` sidecar on TR-claimed workloads — the postsync-reroll verification then fails on every service. Hit this setting up the dev-decoy tenant, which had never received the config.

This replaces the file with the camelCase shape pulled from the staging tenant's live (working) config.

Note for reviewers: the live shape also carries `responseDelay: {mode: RECORDED}` and `evaluationIntervals: 5`, and drops the explicit `passthrough_mode` key (false is the default) — flagging in case any of that drift was unintentional.