### PR TITLE
Fix reroll verification for the eBPF overlay

### DIFF
--- a/kubernetes/overlays/speedscale/responders/README.md
+++ b/kubernetes/overlays/speedscale/responders/README.md
@@ -27,12 +27,14 @@ speedctl push test-config banking-mock-fail-closed.json
 ```
 
 `banking-mock-fail-closed.json` (in this directory) is a fail-closed mock
-config: `responder.passthrough_mode: false` (404 on no-match, no real egress)
-plus `cluster.sidecar_tls_out: true` so the operator still injects the
-`speedscale-goproxy` sidecar. With the sidecar in path goproxy captures each
-outbound rrpair and surfaces it in the live tap. The previous
-`banking-mock-noproxy` config skipped the sidecar, which is why outbound was
-invisible to capture.
+config: no passthrough (404 on no-match, no real egress). Do NOT set
+`cluster.sidecarTlsOut` for tenants running this overlay: these workloads
+carry eBPF capture annotations (`capture.speedscale.com/*`), and the operator
+webhook rejects sidecar injection alongside them ("cannot be used in
+conjunction with sidecar.speedscale.com/inject"), which fails every
+TrafficReplay at init. Outbound visibility here comes from the eBPF tap, not
+a goproxy sidecar; the sidecar-based variant belongs to the
+`speedscale-sidecar` overlay's tenant.
 
 The Speedscale operator must be installed in the cluster.
 

--- a/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
+++ b/kubernetes/overlays/speedscale/responders/tr-postsync-reroll.yaml
@@ -89,10 +89,15 @@ spec:
           }
 
           count_pods_with_speedscale() {
+            # Responder routing needs only the initproxy init container. Do NOT
+            # require the goproxy sidecar here: this overlay captures via eBPF
+            # annotations (capture.speedscale.com/*), and the operator webhook
+            # rejects sidecar injection on those workloads, so a goproxy check
+            # can never pass and wedges the sync.
             kubectl -n "$NS" get pod -l app="$1" \
               --field-selector=status.phase=Running \
               -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.initContainers[*].name}{" "}{.spec.containers[*].name}{"\n"}{end}' 2>/dev/null \
-              | awk '/speedscale-initproxy-responder/ && /speedscale-goproxy/ { n++ } END { print n+0 }'
+              | awk '/speedscale-initproxy-responder/ { n++ } END { print n+0 }'
           }
 
           tr_report_id() {


### PR DESCRIPTION
The `speedscale-postsync-reroll` job verified responder routing by requiring both `speedscale-initproxy-responder` and a `speedscale-goproxy` container on every TR-claimed pod. On this overlay that is unsatisfiable: the workloads carry eBPF capture annotations (`capture.speedscale.com/enabled` / `java-agent`), and the operator webhook (2.5.7xx) rejects sidecar injection on them outright — `"capture.speedscale.com/enabled" cannot be used in conjunction with "sidecar.speedscale.com/inject"`. So the verification failed on every service, the job exited non-zero, and every ArgoCD sync of the app ended Failed (dev-decoy was wedged on this since mid-June).

- Verify the responder initproxy only; env-id label and responder IP checks stay.
- README: document that `sidecarTlsOut` must stay off for tenants running this overlay, and why. The goproxy-sidecar outbound-capture story belongs to the `speedscale-sidecar` overlay.

Open question for a follow-up: if outbound rrpair visibility during responder replay is still wanted on the eBPF overlay, that needs an operator-side answer (webhook currently forbids the combination).