### PR TITLE
Drop sidecar inject annotations from responder TRs

### DIFF
--- a/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
@@ -3,9 +3,6 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-accounts
   namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
 spec:
   # accounts-scoped snapshot (Plaid + OXR + Moody), redacted, pushed to elastic tenant
   snapshotID: 25ef64bf-c07b-4adc-8ae3-33b2d6d5d6cf

--- a/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
@@ -3,9 +3,6 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-ai
   namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: 7f7256a0-8876-4e3f-aea9-3fd681e0c36a
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
@@ -3,9 +3,6 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-fraud
   namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: c3898583-282b-4b82-9bdb-72b7dd45d15c
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -3,9 +3,6 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-notification
   namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
@@ -3,9 +3,6 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-transactions
   namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: c7bc4b14-40bd-46ae-88fd-f366b36de453
   testConfigID: banking-mock-fail-closed

--- a/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
@@ -3,9 +3,6 @@ kind: TrafficReplay
 metadata:
   name: replay-banking-user
   namespace: banking-app
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
 spec:
   snapshotID: 68d2bc15-8931-4093-836e-a5ba3a5a5b5a
   testConfigID: banking-mock-fail-closed


### PR DESCRIPTION
The six responder TrafficReplays carry `sidecar.speedscale.com/inject: true` + `tls-out: true` annotations. The TR claim copies `sidecar.speedscale.com/*` onto the target workload, and since the goproxy-on-eBPF hardening (Linear S-11666) the operator webhook rejects that on workloads with `capture.speedscale.com/*` annotations — so on the eBPF overlay every TR fails at init:

```
admission webhook "sidecar.speedscale.com" denied the request: Invalid workload configuration:
"capture.speedscale.com/enabled" cannot be used in conjunction with "sidecar.speedscale.com/inject"
```

The annotations aren't needed for responder rerouting: the `speedscale-initproxy-responder` init container attaches whenever the replay has a responder service (`operator/webhook/mutate_workload.go`, gated on the responder svc — not on `Sidecar.Inject`). They only added goproxy for outbound TLS visibility, which is precisely what the hardening forbids on eBPF workloads. eBPF capture stays on all services.

No behavior change for the `speedscale-sidecar` overlay (staging-decoy): its workloads inject at the workload level already, so the TR-level annotations were redundant there.

Both overlays render (`kubectl kustomize`). Pairs with #237; together they should take the dev-decoy sync green. Refs Linear S-12361 — the operator-side question (TLS-out visibility during replay on eBPF workloads) stays open there, but the demo no longer depends on it.