### PR TITLE
Add release-gate workflow to the Replay Lab demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ application-local.properties
 # Claude Code
 .claude/
 thoughts/
+gate-out/

--- a/backend/transactions-service/src/main/java/com/banking/transactionsservice/controller/TransactionController.java
+++ b/backend/transactions-service/src/main/java/com/banking/transactionsservice/controller/TransactionController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -36,8 +37,14 @@ public class TransactionController {
     
     @Autowired
     private Tracer tracer;
-    
-    
+
+    // Demo flag: when enabled, deposit responds with a wrapped envelope and 200 OK
+    // instead of the bare TransactionResponse and 201 Created — a plausible
+    // "API standardization" refactor that breaks existing consumers. Used to stage
+    // a contract regression for the Replay Lab demo. Never enable in production.
+    @Value("${demo.contract-refactor.enabled:false}")
+    private boolean contractRefactorEnabled;
+
     @GetMapping
     public ResponseEntity<List<TransactionResponse>> getUserTransactions(
             @RequestParam(required = false) Long accountId) {
@@ -110,21 +117,29 @@ public class TransactionController {
     }
     
     @PostMapping("/deposit")
-    public ResponseEntity<TransactionResponse> deposit(
+    public ResponseEntity<?> deposit(
             @Valid @RequestBody DepositRequest request) {
         Span span = tracer.spanBuilder("process-deposit").startSpan();
         try {
             Long userId = getUserIdFromAuthentication();
-            
-            logger.info("Processing deposit for user: {}, account: {}, amount: {}", 
+
+            logger.info("Processing deposit for user: {}, account: {}, amount: {}",
                        userId, request.getAccountId(), request.getAmount());
-            
+
             TransactionResponse transaction = transactionService.deposit(request, userId, getCurrentRequest());
             span.setAttribute("user.id", userId);
             span.setAttribute("account.id", request.getAccountId());
             span.setAttribute("transaction.amount", request.getAmount().toString());
             span.setAttribute("transaction.id", transaction.getId());
-            
+
+            if (contractRefactorEnabled) {
+                // Standardized response envelope (see demo.contract-refactor.enabled).
+                Map<String, Object> envelope = new HashMap<>();
+                envelope.put("status", "success");
+                envelope.put("data", transaction);
+                return ResponseEntity.ok(envelope);
+            }
+
             return ResponseEntity.status(HttpStatus.CREATED).body(transaction);
         } catch (RuntimeException e) {
             span.recordException(e);

--- a/replay-lab-demo/Makefile
+++ b/replay-lab-demo/Makefile
@@ -1,28 +1,43 @@
-# Replay Lab — local reproduce/fix loop for the banking deposit bug.
+# Replay Lab — both proxymock workflows on the banking transactions-service.
 #
-# proxymock replays a REAL captured production request against the service and mocks
+# proxymock replays REAL captured production traffic against the service and mocks
 # every downstream dependency from REAL recorded traffic. Postgres is the only live
 # dependency (see setup.sh). Logic lives in the *.sh scripts so the commands work the
 # same by hand or under make.
 #
+# Workflow A — release gate (catch it BEFORE prod):
+#   Terminal 1:  make run MEMO_BUG=false                     # prod build
+#   Terminal 2:  make gate                                   # GREEN: 100% match
+#   Terminal 1:  make run MEMO_BUG=false CONTRACT_REFACTOR=true   # agent's build
+#   Terminal 2:  make gate                                   # RED: blocked pre-merge
+#
+# Workflow B — reproduce a live prod issue (fix it FAST):
 #   Terminal 1:  make run         # service + proxymock mock (deps), bug armed
 #   Terminal 2:  make reproduce   # replay the captured prod failure  -> RED  (400)
 #                make fix         # apply the agent's fix, replay      -> GREEN (201)
 #
 SHELL := /bin/bash
 SVC   := backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
-PORT  ?= 8080
+PORT  ?= 8087
 export PORT
+# build flags for run.sh; empty means "use the script default"
+export MEMO_BUG CONTRACT_REFACTOR
 
-.PHONY: help setup run reproduce fix reset down
+.PHONY: help setup run reproduce fix reset down gate record-suite
 help: ## list targets
 	@grep -hE '^[a-z-]+:.*##' $(MAKEFILE_LIST) | sed 's/:.*##/\t/' | column -t -s "$$(printf '\t')"
 
 setup: ## one-time prereqs: postgres + db user + build (single script)
 	@./setup.sh
 
-run: ## terminal 1: proxymock mock (deps) + the service, bug armed
+run: ## terminal 1: proxymock mock (deps) + the service; flags: MEMO_BUG, CONTRACT_REFACTOR
 	@./run.sh
+
+gate: ## release gate: replay prod-suite/ against the running build; exit code = verdict
+	@./gate.sh
+
+record-suite: ## re-record prod-suite/ from the running CLEAN build (make run MEMO_BUG=false)
+	@./record-suite.sh
 
 reproduce: ## terminal 2: replay the captured prod failure against the service
 	@./reproduce.sh

--- a/replay-lab-demo/README.md
+++ b/replay-lab-demo/README.md
@@ -1,90 +1,159 @@
-# Replay Lab — local reproduce → fix → validate loop
+# Replay Lab: verify AI-generated code against production reality
 
-This package reproduces a real production bug **on your laptop**, fixes it, and proves
-the fix — using a **captured production request** and Speedscale **proxymock** to mock
-every downstream dependency. No cluster, no staging, no hand-written test.
+Coding agents make shipping code cheap. Shipped code still has to survive production
+traffic, and new code fails there more often than code review or dashboards catch.
+This demo shows the two loops that close that gap, on your laptop, with **proxymock**
+and traffic captured from a production-like banking app. No cluster, no staging
+environment, no hand-written tests.
 
-It is the [Replay Lab](#where-the-replay-lab-fits) loop shrunk to a single service so you
-can watch every step.
+- **Workflow A, the release gate.** Replay yesterday's production traffic against a
+  candidate build before it merges. A change that passes its own unit tests but
+  breaks real request shapes goes RED in CI, not in prod.
+- **Workflow B, incident reproduction.** A captured production failure replays
+  locally with every dependency mocked: reproduce (RED), fix, prove (GREEN) with the
+  exact request that hurt a real customer.
 
+Both loops run against `transactions-service` from this repo, with every downstream
+dependency (accounts-service, Stripe, PayPal, ComplyAdvantage) served by proxymock
+from recorded traffic. Postgres is the only real dependency.
+
+## Setup (once)
+
+Prereqs: Docker (for Postgres), Java 17+, Maven, and `proxymock`
+(`~/.speedscale/proxymock`).
+
+```bash
+make setup        # start Postgres, create the service DB user, build the jar
 ```
- captured prod request ──▶  reproduce (RED)  ──▶  fix  ──▶  validate (GREEN)
-   real RRPair               replay → 400          patch       replay → 201
-                             deps mocked by proxymock
+
+Every target takes `PORT=…` if 8087 is busy (`make run PORT=8090`, `make gate PORT=8090`).
+`make run` refuses to start if anything else is listening on the port. A half-claimed
+port (say, a container publishing the same port on IPv4 only) answers some clients and
+not others, which is much worse than a clean failure.
+
+## Workflow A: the release gate
+
+The story: an agent "standardized" the deposit API response. It wrapped the body in a
+`{"status", "data"}` envelope and returned `200 OK` instead of `201 Created`. It
+updated the unit tests to match, so CI is green. Every existing consumer of the API
+is now broken. The gate replays recorded production traffic against the candidate
+build and fails unless every request gets the status code production gave it.
+
+```bash
+# terminal 1: the build currently in prod
+make run MEMO_BUG=false
+# terminal 2: gate passes — traffic-proven safe
+make gate
+
+# terminal 1 (Ctrl-C, then): the agent's candidate build
+make run MEMO_BUG=false CONTRACT_REFACTOR=true
+# terminal 2: gate fails — 33% match, both deposits flagged, exit code 1
+make gate
 ```
 
-## The bug
+The same gate catches the workflow-B bug before release (`make run` with the memo
+bug armed fails the gate on exactly the request shape that triggers it). In CI this
+is one step: build, start, `./gate.sh`, and the exit code blocks the merge.
 
-`transactions-service` normalizes a deposit's memo for a downstream ledger feed:
+The suite in `prod-suite/` ships with the demo. To re-record it against a healthy
+build: `make run MEMO_BUG=false` then `make record-suite`.
+
+## Workflow B: reproduce the production incident
+
+The story: deposits from one client are failing in production right now.
+Observability shows a `NullPointerException` count going up; it does not hand you
+the request that causes it. The captured RRPair does:
 
 ```java
 String memo = request.getDescription().trim().toUpperCase();   // NPE when description is null
 ```
 
-Real clients sometimes POST a deposit with **no `description`**. In production that throws a
-`NullPointerException`, the controller traces it and returns an error to the customer — the
-deposit silently fails. Observability shows you the exception; it does **not** hand you the
-exact request that triggered it. The captured RRPair does.
-
-The bug is gated behind `DEMO_MEMO_BUG_ENABLED` so it only arms for this demo.
-
-## Run it
-
-Prereqs: Docker (for Postgres), Java 17+, Maven, and `proxymock` (`~/.speedscale/proxymock`).
+Real clients sometimes POST a deposit with no `description`. The agent that wrote
+the memo feature never sent one that way, and neither did its tests.
 
 ```bash
-make setup        # one-time: start Postgres, create the service DB user, build the jar
-make run          # terminal 1: starts the service + proxymock mock (deps), bug armed
-make reproduce    # terminal 2: replays the captured prod failure   ->  RED   (HTTP 400)
-make fix          #             applies the agent's fix, hot-restarts ->  GREEN (HTTP 201)
-make reset        #             puts the bug back
+# terminal 1: the prod build, bug armed
+make run
+# terminal 2: replay the captured prod failure
+make reproduce    #  RED   — HTTP 400, reproduced on your laptop in seconds
+make fix          #  GREEN — null-guard applied, hot-restarted, same request now 201
+make reset        #  put the bug back for the next run
 make down         # stop the service + mock
 ```
 
-`make run` overrides the port with `PORT=…` if 8080 is taken (e.g. `make run PORT=8090`,
-`make reproduce PORT=8090`).
+The fix is proven with the exact production request, not a test someone wrote to
+pass. That distinction is the point: an agent grading its own homework proves
+nothing; recorded production traffic is ground truth neither the agent nor the
+author can bend.
+
+## Where the traffic comes from
+
+In this demo the RRPairs are committed files so everything runs offline. In a real
+deployment they come out of your own infrastructure. This is the BYOC model:
+
+1. Speedscale capture (sidecar or eBPF tap) records traffic in your cluster.
+2. Traffic lands in **your** object-storage bucket, DLP-redacted before it is
+   written, so tokens, PII, and API keys never leave your account in the clear.
+3. `proxymock pull` (or a Replay Lab snapshot export) brings a time-window of that
+   traffic to a laptop or CI runner as the same RRPair files you see here.
+
+So `captured/` stands in for "the failing request from this morning's incident" and
+`prod-suite/` stands in for "yesterday's good traffic", each one `proxymock pull`
+away. Nothing in either loop touches Speedscale's cloud: capture, storage, and
+replay all run on infrastructure you own.
 
 ## What is real vs mocked
 
 | Dependency | In this demo |
 |---|---|
-| **Postgres** | **real** — local container (`make setup`). JDBC ignores the HTTP proxy, so it stays live. |
+| **Postgres** | **real**: local container (`make setup`). JDBC ignores the HTTP proxy, so it stays live. |
 | accounts-service | **mocked** by proxymock from recorded traffic (`mocks/localhost/`) |
-| Stripe / PayPal / ComplyAdvantage | **mocked** by proxymock (`mocks/api.*`) — the deposit's payment/compliance fan-out |
+| Stripe / PayPal / ComplyAdvantage | **mocked** by proxymock (`mocks/api.*`), the deposit's payment/compliance fan-out |
 | fraud-service (gRPC) | absent → the client **fails open**, exactly as in production |
 
 The service talks to its dependencies through proxymock on `:4140`
-(`-Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140`). proxymock answers each outbound call
-with the **recorded** response, so the whole loop runs offline and deterministically.
+(`-Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140`). proxymock answers each outbound
+call with the **recorded** response, so both loops run offline and deterministically.
 
 ## What's in the box
 
 ```
-captured/deposit-failure.md   the real captured production failure (POST /deposit, no description -> 400)
+captured/deposit-failure.md   the captured production failure (POST /deposit, no description -> 400)
+prod-suite/localhost/*.md     recorded production traffic for the release gate (3 requests)
 mocks/localhost/*.md          recorded accounts-service responses (validate, get-balance, update-balance)
 mocks/api.*/*.md              recorded payment/compliance responses
 fix.patch                     the one-line null-guard fix (applied by `make fix`)
+gate.sh                       the CI release gate (replay + --fail-if, exit code = verdict)
+record-suite.sh               re-record prod-suite/ from a healthy build
+warmup.sh                     readiness probe shared by the replay scripts
 setup.sh run.sh reproduce.sh fix.sh   the steps, as plain scripts (make just calls them)
 ```
+
+Both staged defects are env-gated so the same jar plays every role:
+`DEMO_MEMO_BUG_ENABLED` (workflow B's NPE) and `DEMO_CONTRACT_REFACTOR_ENABLED`
+(workflow A's envelope change). `run.sh` exposes them as `MEMO_BUG` / `CONTRACT_REFACTOR`.
 
 The mocks were produced by recording one successful deposit against the real services:
 
 ```bash
-proxymock record --app-port 8080 -- java -Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140 -jar <service>.jar
+proxymock record --app-port 8087 -- java -Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140 -jar <service>.jar
 # drive one good deposit through :4143, then reuse the recorded OUT pairs as mocks
 ```
 
-Because they are real recordings (not hand-written), proxymock matches them by signature with
-no fix-ups.
+Because they are real recordings (not hand-written), proxymock matches them by
+signature with no fix-ups. One constraint that keeps the suite deterministic: the
+recorded accounts-service mock matches the downstream balance update by exact body,
+so suite deposits stay at amount `3.33` on account `70668`.
 
 ## Where the Replay Lab fits
 
-- **proxymock** is the **replay engine** — the thing you just ran on your laptop. It captures
-  traffic, mocks dependencies, and replays a request against your code.
-- **Replay Lab** is the **product** that runs this exact loop **continuously, in a cluster,
-  against live production traffic**: the forwarder streams captured traffic in, a work queue
-  picks failing requests, each one is replayed in an isolated runner (deps mocked, just like
-  here), and the result is bug evidence + release confidence — reproduce, fix, validate, repeat.
+- **proxymock** is the **replay engine**, the thing you just ran on your laptop. It
+  captures traffic, mocks dependencies, and replays requests against your code.
+- **Replay Lab** is the **product** that runs these exact loops **continuously,
+  against live production traffic**: capture streams into your bucket, a work queue
+  picks failing requests, each one replays in an isolated runner (deps mocked, just
+  like here), and the release gate runs on every merge request.
 
-This demo is that loop, by hand, on one bug: **capture → reproduce → fix → validate**. The
-Replay Lab is the same four steps, automated and always-on.
+This demo is both loops, by hand, on one service: **gate before release, reproduce
+when something slips through**. The Replay Lab is the same two loops, automated and
+always-on.

--- a/replay-lab-demo/fix.sh
+++ b/replay-lab-demo/fix.sh
@@ -16,4 +16,4 @@ echo ">> recompiling (spring-boot devtools hot-restarts the running service)"
 
 echo ">> waiting for hot-restart..."
 sleep 10
-PORT="${PORT:-8080}" ./reproduce.sh
+PORT="${PORT:-8087}" ./reproduce.sh

--- a/replay-lab-demo/gate.sh
+++ b/replay-lab-demo/gate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Release gate: replay recorded production traffic (prod-suite/) against the
+# candidate build and fail unless every request returns the same status code
+# production returned. This is the CI step — exit code is the verdict.
+#
+#   ./gate.sh            # against localhost:$PORT (default 8087)
+set -euo pipefail
+cd "$(dirname "$0")"
+PM="$HOME/.speedscale/proxymock"
+PORT="${PORT:-8087}"
+
+./warmup.sh
+
+echo ">> replaying recorded production traffic against the candidate build"
+rm -rf gate-out
+if "$PM" replay --in prod-suite --test-against "http://localhost:$PORT" \
+     --out gate-out --fail-if "requests.result-match-pct != 100" 2>&1 \
+     | sed -n '/LATENCY \/ THROUGHPUT/,$p'; then
+  echo
+  echo "  GATE PASSED — candidate build matches production behavior on real traffic"
+else
+  echo
+  echo "  GATE FAILED — candidate build diverges from production behavior (see table above)"
+  exit 1
+fi

--- a/replay-lab-demo/prod-suite/localhost/2026-07-06_17-24-06.566125Z.md
+++ b/replay-lab-demo/prod-suite/localhost/2026-07-06_17-24-06.566125Z.md
@@ -1,0 +1,197 @@
+### REQUEST ###
+```
+GET http://localhost:8087/api/transactions HTTP/1.1
+Accept: */*
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Content-Type: application/json
+Host: localhost:8087
+User-Agent: curl/8.7.1
+```
+
+```
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Date: Mon\, 06 Jul 2026 17:24:06 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+[
+  {
+    "id": 23,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-07-06T13:16:02.773109",
+    "processedAt": "2026-07-06T13:16:02.772813"
+  },
+  {
+    "id": 22,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-07-06T13:15:49.621017",
+    "processedAt": "2026-07-06T13:15:49.620746"
+  },
+  {
+    "id": 21,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-07-06T13:14:00.388619",
+    "processedAt": "2026-07-06T13:14:00.383634"
+  },
+  {
+    "id": 20,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T14:34:30.406731",
+    "processedAt": "2026-06-25T14:34:30.394388"
+  },
+  {
+    "id": 19,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T14:31:51.950964",
+    "processedAt": "2026-06-25T14:31:51.94512"
+  },
+  {
+    "id": 18,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T14:26:48.914294",
+    "processedAt": "2026-06-25T14:26:48.906764"
+  },
+  {
+    "id": 17,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": "ledger sync",
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T14:26:02.316611",
+    "processedAt": "2026-06-25T14:26:02.307998"
+  },
+  {
+    "id": 15,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 10.0,
+    "type": "DEPOSIT",
+    "description": "ledger sync",
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T14:18:26.018592",
+    "processedAt": "2026-06-25T14:18:26.010452"
+  },
+  {
+    "id": 14,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T08:35:52.402688",
+    "processedAt": "2026-06-25T08:35:52.397304"
+  },
+  {
+    "id": 13,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T08:33:33.396853",
+    "processedAt": "2026-06-25T08:33:33.396614"
+  },
+  {
+    "id": 11,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": "groceries",
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T08:31:42.527561",
+    "processedAt": "2026-06-25T08:31:42.527356"
+  },
+  {
+    "id": 9,
+    "userId": 1,
+    "fromAccountId": null,
+    "toAccountId": 70668,
+    "amount": 3.33,
+    "type": "DEPOSIT",
+    "description": null,
+    "status": "COMPLETED",
+    "createdAt": "2026-06-25T08:31:37.526287",
+    "processedAt": "2026-06-25T08:31:37.526086"
+  }
+]
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is GET
+http:queryparams is -NONE-
+http:url is /api/transactions
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: a2edfd3f-1553-496f-9113-2b1c2fef578e
+ts: 2026-07-06T17:24:06.566125Z
+duration: 11ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.733, reverseProxyHost=localhost, reverseProxyPort=8087, sequence=2, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-07-06T17:24:06.566125Z","l7protocol":"http","duration":11,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.733","reverseProxyHost":"localhost","reverseProxyPort":"8087","sequence":"2","source":"goproxy"},"uuid":"ou39PxVTSW+REyscL+9Xjg==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","command":"GET","location":"/api/transactions","status":"200","http":{"req":{"url":"/api/transactions","uri":"/api/transactions","version":"1.1","method":"GET","host":"localhost:8087"},"res":{"contentType":"application/json","statusCode":200,"statusMessage":"200 OK"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"R0VU","http:queryparams":"","http:url":"L2FwaS90cmFuc2FjdGlvbnM="},"netinfo":{"id":"1","startTime":"2026-07-06T17:24:06.566037Z","downstream":{"established":"2026-07-06T17:24:06.565195Z","ipAddress":"127.0.0.1","port":53421,"bytesSent":"324"},"upstream":{"established":"2026-07-06T17:24:06.565749Z","ipAddress":"127.0.0.1","port":8087,"hostname":"localhost","bytesSent":"3013"}}}
+```

--- a/replay-lab-demo/prod-suite/localhost/2026-07-06_17-24-06.586622Z.md
+++ b/replay-lab-demo/prod-suite/localhost/2026-07-06_17-24-06.586622Z.md
@@ -1,0 +1,69 @@
+### REQUEST ###
+```
+POST http://localhost:8087/api/transactions/deposit HTTP/1.1
+Accept: */*
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Content-Type: application/json
+Host: localhost:8087
+User-Agent: curl/8.7.1
+```
+
+```
+{
+  "accountId": 70668,
+  "amount": 3.33,
+  "description": "payroll deposit"
+}
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 201 Created
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Date: Mon\, 06 Jul 2026 17:24:06 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "id": 24,
+  "userId": 1,
+  "fromAccountId": null,
+  "toAccountId": 70668,
+  "amount": 3.33,
+  "type": "DEPOSIT",
+  "description": "payroll deposit",
+  "status": "COMPLETED",
+  "createdAt": "2026-07-06T13:24:06.694993",
+  "processedAt": "2026-07-06T13:24:06.69106"
+}
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is POST
+http:queryparams is -NONE-
+http:requestBodyJSON is {"accountId":70668,"amount":3.33,"description":"payroll deposit"}
+http:url is /api/transactions/deposit
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: f582770e-585f-4f41-88b4-16ffed93ec1a
+ts: 2026-07-06T17:24:06.586622Z
+duration: 174ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.733, reverseProxyHost=localhost, reverseProxyPort=8087, sequence=4, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-07-06T17:24:06.586622Z","l7protocol":"http","duration":174,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.733","reverseProxyHost":"localhost","reverseProxyPort":"8087","sequence":"4","source":"goproxy"},"uuid":"9YJ3DlhfT0GItBb/7ZPsGg==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","command":"POST","location":"/api/transactions/deposit","status":"201","http":{"req":{"url":"/api/transactions/deposit","uri":"/api/transactions/deposit","version":"1.1","method":"POST","host":"localhost:8087"},"res":{"contentType":"application/json","statusCode":201,"statusMessage":"201 Created"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UE9TVA==","http:queryparams":"","http:requestBodyJSON":"eyJhY2NvdW50SWQiOjcwNjY4LCJhbW91bnQiOjMuMzMsImRlc2NyaXB0aW9uIjoicGF5cm9sbCBkZXBvc2l0In0=","http:url":"L2FwaS90cmFuc2FjdGlvbnMvZGVwb3NpdA=="},"netinfo":{"id":"2","startTime":"2026-07-06T17:24:06.586577Z","downstream":{"established":"2026-07-06T17:24:06.586215Z","ipAddress":"127.0.0.1","port":53424,"bytesSent":"418"},"upstream":{"established":"2026-07-06T17:24:06.586537Z","ipAddress":"127.0.0.1","port":8087,"hostname":"localhost","bytesSent":"612"}}}
+```

--- a/replay-lab-demo/prod-suite/localhost/2026-07-06_17-24-06.769462Z.md
+++ b/replay-lab-demo/prod-suite/localhost/2026-07-06_17-24-06.769462Z.md
@@ -1,0 +1,68 @@
+### REQUEST ###
+```
+POST http://localhost:8087/api/transactions/deposit HTTP/1.1
+Accept: */*
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck
+Content-Type: application/json
+Host: localhost:8087
+User-Agent: curl/8.7.1
+```
+
+```
+{
+  "accountId": 70668,
+  "amount": 3.33
+}
+```
+
+### RESPONSE ###
+```
+HTTP/1.1 201 Created
+Cache-Control: no-cache\, no-store\, max-age=0\, must-revalidate
+Content-Type: application/json
+Date: Mon\, 06 Jul 2026 17:24:06 GMT
+Expires: 0
+Pragma: no-cache
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-Xss-Protection: 0
+```
+
+```
+{
+  "id": 25,
+  "userId": 1,
+  "fromAccountId": null,
+  "toAccountId": 70668,
+  "amount": 3.33,
+  "type": "DEPOSIT",
+  "description": null,
+  "status": "COMPLETED",
+  "createdAt": "2026-07-06T13:24:06.77832",
+  "processedAt": "2026-07-06T13:24:06.778094"
+}
+```
+
+### SIGNATURE ###
+```
+http:host is localhost
+http:method is POST
+http:queryparams is -NONE-
+http:requestBodyJSON is {"accountId":70668,"amount":3.33}
+http:url is /api/transactions/deposit
+```
+
+### METADATA ###
+```
+direction: IN
+uuid: 032d0436-a1b2-4bc3-a716-4a1c993bf2eb
+ts: 2026-07-06T17:24:06.769462Z
+duration: 13ms
+tags: captureMode=proxy, k8sAppLabel=my-app, proxyProtocol=tcp:http, proxyType=dual, proxyVersion=v2.5.733, reverseProxyHost=localhost, reverseProxyPort=8087, sequence=6, source=goproxy
+```
+
+### INTERNAL - DO NOT MODIFY ###
+```
+json: {"msgType":"rrpair","resource":"my-app","ts":"2026-07-06T17:24:06.769462Z","l7protocol":"http","duration":13,"tags":{"captureMode":"proxy","k8sAppLabel":"my-app","proxyLocation":"in","proxyProtocol":"tcp:http","proxyType":"dual","proxyVersion":"v2.5.733","reverseProxyHost":"localhost","reverseProxyPort":"8087","sequence":"6","source":"goproxy"},"uuid":"Ay0ENqGyS8OnFkocmTvy6w==","direction":"IN","cluster":"undefined","namespace":"undefined","service":"my-app","command":"POST","location":"/api/transactions/deposit","status":"201","http":{"req":{"url":"/api/transactions/deposit","uri":"/api/transactions/deposit","version":"1.1","method":"POST","host":"localhost:8087"},"res":{"contentType":"application/json","statusCode":201,"statusMessage":"201 Created"}},"signature":{"http:host":"bG9jYWxob3N0","http:method":"UE9TVA==","http:queryparams":"","http:requestBodyJSON":"eyJhY2NvdW50SWQiOjcwNjY4LCJhbW91bnQiOjMuMzN9","http:url":"L2FwaS90cmFuc2FjdGlvbnMvZGVwb3NpdA=="},"netinfo":{"id":"3","startTime":"2026-07-06T17:24:06.769425Z","downstream":{"established":"2026-07-06T17:24:06.769038Z","ipAddress":"127.0.0.1","port":53432,"bytesSent":"386"},"upstream":{"established":"2026-07-06T17:24:06.769375Z","ipAddress":"127.0.0.1","port":8087,"hostname":"localhost","bytesSent":"599"}}}
+```

--- a/replay-lab-demo/record-suite.sh
+++ b/replay-lab-demo/record-suite.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Re-record the release-gate suite (prod-suite/) from the running service.
+#
+# Run this against the CLEAN build (make run MEMO_BUG=false) — the suite is
+# "yesterday's good production traffic", so every request must succeed the way
+# production did. A committed suite ships with the demo; you only need this to
+# regenerate it.
+#
+# proxymock record puts an inbound proxy on :4143 in front of the app; requests
+# driven through it are captured as localhost RRPairs, which become the suite.
+set -euo pipefail
+cd "$(dirname "$0")"
+PM="$HOME/.speedscale/proxymock"
+PORT="${PORT:-8087}"
+JWT_TOKEN='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck'
+
+./warmup.sh
+
+REC=$(mktemp -d)
+# --proxy-out-port: the mock already owns :4140 (the app's outbound proxy); the
+# recorder's own outbound listener is unused here, park it on :4141
+"$PM" record --app-port "$PORT" --proxy-out-port 4141 --out "$REC" >/tmp/replay-lab-record.log 2>&1 &
+REC_PID=$!
+trap 'kill $REC_PID 2>/dev/null || true' EXIT
+sleep 3
+
+req() { # method path [json-body]
+  local method=$1 path=$2 body=${3:-}
+  local args=(-s -o /dev/null -w "%{http_code}" -X "$method"
+              -H "Authorization: Bearer $JWT_TOKEN" -H 'Content-Type: application/json')
+  [ -n "$body" ] && args+=(-d "$body")
+  local code
+  code=$(curl "${args[@]}" "http://localhost:4143$path")
+  echo "  $method $path -> $code"
+}
+
+echo ">> driving the suite through the recording proxy :4143"
+req GET  /api/transactions
+# amount must stay 3.33 on account 70668: the recorded accounts-service mock
+# matches the downstream PUT /balance by exact body ({"balance":1003.33})
+req POST /api/transactions/deposit '{"accountId":70668,"amount":3.33,"description":"payroll deposit"}'
+req POST /api/transactions/deposit '{"accountId":70668,"amount":3.33}'
+
+sleep 2
+kill $REC_PID 2>/dev/null || true; wait $REC_PID 2>/dev/null || true
+
+[ -d "$REC/localhost" ] || { echo "recording produced no inbound traffic (see /tmp/replay-lab-record.log)"; exit 1; }
+rm -rf prod-suite
+mkdir -p prod-suite
+cp -R "$REC/localhost" prod-suite/localhost
+rm -rf "$REC"
+echo ">> suite written to prod-suite/ ($(ls prod-suite/localhost | wc -l | tr -d ' ') requests)"

--- a/replay-lab-demo/reproduce.sh
+++ b/replay-lab-demo/reproduce.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 PM="$HOME/.speedscale/proxymock"
-PORT="${PORT:-8080}"
+PORT="${PORT:-8087}"
+
+./warmup.sh
 
 rm -rf out
 "$PM" replay --in captured --test-against "http://localhost:$PORT" --out out >/dev/null 2>&1 || true

--- a/replay-lab-demo/run.sh
+++ b/replay-lab-demo/run.sh
@@ -7,15 +7,29 @@ DEMO="$PWD"
 ROOT="$(cd .. && pwd)"
 TX="$ROOT/backend/transactions-service"
 PM="$HOME/.speedscale/proxymock"
-PORT="${PORT:-8080}"
+PORT="${PORT:-8087}"
 JWT='banking-app-super-secret-key-change-this-in-production-256-bit'
+
+# A squatter on the port (even IPv4-only, e.g. a docker port-forward) silently
+# answers some clients while the app answers others — fail loudly instead.
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "!! something is already listening on :$PORT:" >&2
+  lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >&2
+  echo "!! pick another port: make run PORT=8090" >&2
+  exit 1
+fi
 
 # proxymock mock: app -> proxy :4140 -> recorded response (accounts, stripe, paypal, complyadvantage)
 "$PM" mock --in mocks --no-out >/tmp/replay-lab-mock.log 2>&1 &
 MOCK_PID=$!
 trap 'kill $MOCK_PID 2>/dev/null || true' EXIT
 echo ">> proxymock mock serving deps on :4140  (accounts, stripe, paypal, complyadvantage)"
-echo ">> starting transactions-service on :$PORT  (deps mocked, bug armed)"
+
+# Which build is running? memo-bug defaults ON for the classic reproduce/fix loop;
+# the gate demo overrides per scenario (MEMO_BUG=false, CONTRACT_REFACTOR=true, ...).
+MEMO_BUG="${MEMO_BUG:-true}"
+CONTRACT_REFACTOR="${CONTRACT_REFACTOR:-false}"
+echo ">> starting transactions-service on :$PORT  (deps mocked, memo-bug=$MEMO_BUG, contract-refactor=$CONTRACT_REFACTOR)"
 echo
 
 cd "$TX"
@@ -26,6 +40,7 @@ exec env \
   DB_USERNAME=transactions_service_user DB_PASSWORD=transactions_service_pass DB_SCHEMA=transactions_service \
   JWT_SECRET="$JWT" ACCOUNTS_SERVICE_URL=http://localhost:8082 \
   FRAUD_SERVICE_HOST=localhost FRAUD_SERVICE_PORT=9999 \
-  OTEL_SDK_DISABLED=true DEMO_MEMO_BUG_ENABLED=true SERVER_PORT="$PORT" \
+  OTEL_SDK_DISABLED=true SERVER_PORT="$PORT" \
+  DEMO_MEMO_BUG_ENABLED="$MEMO_BUG" DEMO_CONTRACT_REFACTOR_ENABLED="$CONTRACT_REFACTOR" \
   mvn -q -o spring-boot:run \
     -Dspring-boot.run.jvmArguments="-Dhttp.proxyHost=localhost -Dhttp.proxyPort=4140 -Dhttp.nonProxyHosts= -Dspring.kafka.producer.properties.max.block.ms=1500"

--- a/replay-lab-demo/warmup.sh
+++ b/replay-lab-demo/warmup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Wait until the service is ready AND its security chain has served one real request.
+# The very first authenticated request after a cold start can 401 while Spring
+# finishes lazy init; replaying before that produces a false RED. Sourced by the
+# replay scripts, or run standalone.
+set -euo pipefail
+PORT="${PORT:-8087}"
+JWT_TOKEN='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZXBsYXktbGFiLWRlbW8iLCJ1c2VySWQiOiIxIiwicm9sZXMiOiJVU0VSIiwiZXhwIjoxODkzNDU2MDAwfQ.ZgLN1WSTSnb4u6vvk-z4k8eX7_FIRiK_Uijb0Jkk3Ck'
+
+for _ in $(seq 1 60); do
+  curl -sf -o /dev/null "http://localhost:$PORT/actuator/health" && break
+  sleep 2
+done
+
+# one throwaway authenticated request warms the JWT filter chain
+for _ in $(seq 1 10); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $JWT_TOKEN" "http://localhost:$PORT/api/transactions")
+  [ "$code" = "200" ] && exit 0
+  sleep 1
+done
+echo "warmup: service on :$PORT never served an authenticated request (last: $code)" >&2
+exit 1


### PR DESCRIPTION
Extends `replay-lab-demo/` from one workflow (reproduce a captured production failure, fix, prove) to both Replay Lab loops, all local: proxymock mocks every downstream, Postgres is the only real dependency, no cluster.

**Release gate (new).** `make gate` replays recorded production traffic (`prod-suite/`, committed) against the running build and fails unless every request returns the status code production returned. A second env-gated staged defect, `DEMO_CONTRACT_REFACTOR_ENABLED`, wraps the deposit response in an envelope and returns 200 instead of 201: unit-test-green, consumer-breaking, and the gate catches it (33% match, exit 1). The gate also catches the existing memo bug pre-release (67% match). `make record-suite` regenerates the suite from a healthy build.

**Hardening found during verification.**
- Default port moves 8080 -> 8087 with a bind-conflict preflight in `run.sh`. An unrelated container publishing 8080 on IPv4 only was silently splitting traffic: IPv6 clients reached the demo service, IPv4 clients reached the other container.
- `warmup.sh` (readiness + one authenticated request) runs before every replay; the first authenticated request after a cold start could 401 and produce a false RED.
- `record-suite.sh` parks the recorder's outbound listener on 4141 since the mock owns 4140.

Verified end to end on proxymock v2.5.722: gate PASS on clean build (100%), gate FAIL on both staged defects, reproduce RED (400) -> fix GREEN (201) -> reset, and `mvn package` on this base.

Residual risk: the suite's deposits are pinned to amount 3.33 / account 70668 because the recorded accounts-service mock matches the balance PUT by exact body; changing suite amounts requires re-recording the mocks. The demo README documents this.