### PR TITLE
Pull the live incident from the Replay Lab BYOC export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ application-local.properties
 .claude/
 thoughts/
 gate-out/
+replay-lab-demo/incident/
+replay-lab-demo/incident-mocks/
+replay-lab-demo/incident-out/

--- a/replay-lab-demo/Makefile
+++ b/replay-lab-demo/Makefile
@@ -20,10 +20,10 @@ SHELL := /bin/bash
 SVC   := backend/transactions-service/src/main/java/com/banking/transactionsservice/service/TransactionService.java
 PORT  ?= 8087
 export PORT
-# build flags for run.sh; empty means "use the script default"
-export MEMO_BUG CONTRACT_REFACTOR
+# flags for run.sh/reproduce.sh; empty means "use the script default"
+export MEMO_BUG CONTRACT_REFACTOR MOCKS IN
 
-.PHONY: help setup run reproduce fix reset down gate record-suite
+.PHONY: help setup run reproduce fix reset down gate record-suite incident
 help: ## list targets
 	@grep -hE '^[a-z-]+:.*##' $(MAKEFILE_LIST) | sed 's/:.*##/\t/' | column -t -s "$$(printf '\t')"
 
@@ -38,6 +38,9 @@ gate: ## release gate: replay prod-suite/ against the running build; exit code =
 
 record-suite: ## re-record prod-suite/ from the running CLEAN build (make run MEMO_BUG=false)
 	@./record-suite.sh
+
+incident: ## pull the live failing traffic from the replay-lab BYOC export + craft mocks
+	@./incident.sh
 
 reproduce: ## terminal 2: replay the captured prod failure against the service
 	@./reproduce.sh

--- a/replay-lab-demo/README.md
+++ b/replay-lab-demo/README.md
@@ -71,12 +71,34 @@ String memo = request.getDescription().trim().toUpperCase();   // NPE when descr
 Real clients sometimes POST a deposit with no `description`. The agent that wrote
 the memo feature never sent one that way, and neither did its tests.
 
+**Live pull** (staging-decoy access required): grab the actual failing requests
+from the BYOC bucket via the Replay Lab export, with dependency mocks crafted to
+match whatever account the incident hit:
+
 ```bash
-# terminal 1: the prod build, bug armed
-make run
-# terminal 2: replay the captured prod failure
-make reproduce    #  RED   — HTTP 400, reproduced on your laptop in seconds
-make fix          #  GREEN — null-guard applied, hot-restarted, same request now 201
+make incident     # port-forward, export failing traffic, craft matched mocks
+# terminal 1: the prod build, bug armed, deps from the incident pull
+make run MOCKS=incident-mocks
+# terminal 2: replay the pulled prod failure
+make reproduce IN=incident/localhost   #  RED   — the production 400, on your laptop
+make fix IN=incident/localhost         #  GREEN — null-guard applied, same request now 201
+make reset && make down
+```
+
+The pulled RRPair carries the same `traceparent` as the failing span in the
+tracing backend, so the evidence chain is: dashboard shows the error rate, the
+trace shows a 48-byte request body it cannot give you, the RRPair is those 48
+bytes. Errors fire in bursts, so if `make incident` reports no failing traffic,
+rerun it a few minutes after the next burst (the export's `window` param widens
+the scan once replay-lab !61 is deployed).
+
+**Offline fallback**: a committed capture of the same failure ships in
+`captured/`, so the loop also runs with no cluster access at all:
+
+```bash
+make run          # terminal 1
+make reproduce    #  RED   — HTTP 400
+make fix          #  GREEN — HTTP 201
 make reset        #  put the bug back for the next run
 make down         # stop the service + mock
 ```
@@ -88,19 +110,20 @@ author can bend.
 
 ## Where the traffic comes from
 
-In this demo the RRPairs are committed files so everything runs offline. In a real
-deployment they come out of your own infrastructure. This is the BYOC model:
+`make incident` does the pull for real — this is the BYOC model end to end:
 
-1. Speedscale capture (sidecar or eBPF tap) records traffic in your cluster.
+1. Speedscale capture (sidecar or eBPF tap) records traffic in the cluster.
 2. Traffic lands in **your** object-storage bucket, DLP-redacted before it is
-   written, so tokens, PII, and API keys never leave your account in the clear.
-3. `proxymock pull` (or a Replay Lab snapshot export) brings a time-window of that
-   traffic to a laptop or CI runner as the same RRPair files you see here.
+   written, so keys and PII never leave your account in the clear.
+3. The Replay Lab export endpoint filters that bucket by service, route, and
+   status and streams back a tar.gz of RRPairs plus downstream mocks —
+   `incident.sh` is a port-forward and one `curl` around it.
 
-So `captured/` stands in for "the failing request from this morning's incident" and
-`prod-suite/` stands in for "yesterday's good traffic", each one `proxymock pull`
-away. Nothing in either loop touches Speedscale's cloud: capture, storage, and
-replay all run on infrastructure you own.
+The committed `captured/` and `prod-suite/` files are earlier pulls of the same
+traffic, kept so the loops run offline. Nothing in either loop touches
+Speedscale's cloud: capture, storage, and replay all run on infrastructure you
+own. Incident pulls land in `incident/` and `incident-mocks/`, which are
+gitignored — they carry live (short-lived) bearer tokens from the capture.
 
 ## What is real vs mocked
 
@@ -124,6 +147,8 @@ mocks/localhost/*.md          recorded accounts-service responses (validate, get
 mocks/api.*/*.md              recorded payment/compliance responses
 fix.patch                     the one-line null-guard fix (applied by `make fix`)
 gate.sh                       the CI release gate (replay + --fail-if, exit code = verdict)
+incident.sh                   pull the live failing traffic from the replay-lab BYOC export
+craft-mocks.py                derive account-matched accounts mocks for a pulled incident
 record-suite.sh               re-record prod-suite/ from a healthy build
 warmup.sh                     readiness probe shared by the replay scripts
 setup.sh run.sh reproduce.sh fix.sh   the steps, as plain scripts (make just calls them)

--- a/replay-lab-demo/craft-mocks.py
+++ b/replay-lab-demo/craft-mocks.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Craft account-matched dependency mocks for a pulled incident snapshot.
+
+A failing request usually dies before fanning out, so the incident export has
+no dependency traffic for that account and a post-fix replay would have nothing
+to answer the accounts-service calls. This derives them from the committed
+mocks/localhost recordings: swap the account id and set the balance PUT to
+base-balance + deposit amount (the exact body is part of the mock signature).
+
+The INTERNAL json block carries base64-encoded signature fields, so a plain
+sed is not enough - the signature is decoded, patched, and re-encoded here.
+
+Usage: craft-mocks.py <incident-dir> <mocks-out-dir>
+"""
+import base64
+import json
+import os
+import re
+import shutil
+import sys
+
+TEMPLATES = {
+    "get-account": "2026-06-25_18-26-02.244952Z.md",
+    "get-balance": "2026-06-25_18-26-02.26794Z.md",
+    "put-balance": "2026-06-25_18-26-02.307187Z.md",
+}
+TEMPLATE_ACCOUNT = "70668"
+TEMPLATE_BASE_BALANCE = 1000.00
+TEMPLATE_PUT_BALANCE = "1003.33"
+
+
+def inbound_deposits(incident_dir):
+    """Yield (accountId, amount) for each exported failing deposit."""
+    seen = set()
+    localhost = os.path.join(incident_dir, "localhost")
+    for name in sorted(os.listdir(localhost)):
+        if not name.endswith(".md"):
+            continue
+        txt = open(os.path.join(localhost, name)).read()
+        m = re.search(r"json: (\{.*\})", txt)
+        if not m:
+            continue
+        rec = json.loads(m.group(1))
+        if rec.get("location") != "/api/transactions/deposit":
+            continue
+        req = re.search(r"### REQUEST ###.*?```\n(\{.*?\})\n```", txt, re.S)
+        if not req:
+            continue
+        body = json.loads(req.group(1))
+        key = (body.get("accountId"), body.get("amount"))
+        if None in key or key in seen:
+            continue
+        seen.add(key)
+        yield key
+
+
+def craft(template_path, out_path, swaps):
+    txt = open(template_path).read()
+    m = re.search(r"json: (\{.*\})", txt)
+    rec = json.loads(m.group(1))
+    for old, new in swaps:
+        rec["location"] = rec["location"].replace(old, new)
+        req = rec["http"]["req"]
+        for k in ("url", "uri"):
+            req[k] = req[k].replace(old, new)
+        if "bodyJSON" in req:
+            req["bodyJSON"] = req["bodyJSON"].replace(old, new)
+    sig = rec.get("signature", {})
+    for k, v in list(sig.items()):
+        plain = base64.b64decode(v).decode() if v else ""
+        for old, new in swaps:
+            plain = plain.replace(old, new)
+        if plain:
+            sig[k] = base64.b64encode(plain.encode()).decode()
+    for old, new in swaps:
+        txt = txt.replace(old, new)
+    fixed = json.dumps(rec, separators=(",", ":"))
+    txt = re.sub(r"json: \{.*\}", "json: " + fixed.replace("\\", "\\\\"), txt)
+    open(out_path, "w").write(txt)
+
+
+def main():
+    incident_dir, out_dir = sys.argv[1], sys.argv[2]
+    demo = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(demo, "mocks")
+
+    # start from the committed mocks (payment/compliance hosts stay as-is)
+    if os.path.isdir(out_dir):
+        shutil.rmtree(out_dir)
+    shutil.copytree(src, out_dir)
+
+    deposits = list(inbound_deposits(incident_dir))
+    if not deposits:
+        print("no failing deposits found in", incident_dir)
+        sys.exit(1)
+
+    for account_id, amount in deposits:
+        account = str(account_id)
+        # repr() gives the shortest round-trip decimal, matching Jackson's
+        # Double serialization for these sums; keep base balance at 1000.00
+        new_balance = repr(float(TEMPLATE_BASE_BALANCE) + float(amount))
+        for kind, fname in TEMPLATES.items():
+            swaps = [(TEMPLATE_ACCOUNT, account)]
+            if kind == "put-balance":
+                swaps.append((TEMPLATE_PUT_BALANCE, new_balance))
+            out = os.path.join(
+                out_dir, "localhost", fname.replace(".md", f"-{account}.md")
+            )
+            craft(os.path.join(src, "localhost", fname), out, swaps)
+        print(f"crafted accounts mocks: account {account}, deposit {amount}, "
+              f"balance {TEMPLATE_BASE_BALANCE} -> {new_balance}")
+
+
+if __name__ == "__main__":
+    main()

--- a/replay-lab-demo/fix.sh
+++ b/replay-lab-demo/fix.sh
@@ -16,4 +16,4 @@ echo ">> recompiling (spring-boot devtools hot-restarts the running service)"
 
 echo ">> waiting for hot-restart..."
 sleep 10
-PORT="${PORT:-8087}" ./reproduce.sh
+PORT="${PORT:-8087}" IN="${IN:-captured}" ./reproduce.sh

--- a/replay-lab-demo/incident.sh
+++ b/replay-lab-demo/incident.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Pull the live production incident from the Replay Lab and stage it locally:
+#
+#   1. port-forward the replay-lab control service (staging-decoy)
+#   2. export the failing traffic window from the BYOC bucket (RRPairs + mocks)
+#   3. craft account-matched accounts-service mocks for the post-fix replay
+#
+# Then, in two terminals:
+#   make run MOCKS=incident-mocks            # buggy build + incident deps
+#   make reproduce IN=incident/localhost     # RED  (the captured prod 400)
+#   make fix                                 # GREEN (same request, 201)
+#
+# The errors fire in ~10 minute bursts and the deployed export scans only the
+# newest few minutes of a busy service, so a 404 here usually means "between
+# bursts" - wait for the next burst (watch the Grafana errors dashboard) and
+# rerun. Once replay-lab !61 is deployed the window/batches params below make
+# the pull time-insensitive.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CTX="${CTX:-do-nyc1-staging-decoy}"
+SERVICE="${SERVICE:-banking-transactions}"
+ROUTE="${ROUTE:-/api/transactions/deposit}"
+STATUS="${STATUS:-400}"
+WINDOW="${WINDOW:-45m}"     # inert until replay-lab !61 deploys, then honored
+BATCHES="${BATCHES:-2000}"
+LOCAL_PORT=28080
+
+command -v kubectl >/dev/null || { echo "kubectl is required"; exit 1; }
+kubectl --context "$CTX" get ns replay-lab >/dev/null 2>&1 \
+  || { echo "no access to context $CTX / namespace replay-lab"; exit 1; }
+
+kubectl --context "$CTX" -n replay-lab port-forward svc/replay-lab-control "$LOCAL_PORT:80" >/dev/null 2>&1 &
+PF=$!
+trap 'kill $PF 2>/dev/null || true' EXIT
+
+# wait for the tunnel; curl 000 = not up yet
+for _ in $(seq 1 15); do
+  READY=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$LOCAL_PORT/healthz" || echo 000)
+  [ "$READY" != "000" ] && break
+  sleep 1
+done
+[ "$READY" = "000" ] && { echo "port-forward to replay-lab-control never came up"; exit 1; }
+
+URL="http://localhost:$LOCAL_PORT/api/snapshots/export?service=$SERVICE&route=$ROUTE&status=$STATUS&mocks=true&window=$WINDOW&batches=$BATCHES"
+echo ">> exporting failing traffic: service=$SERVICE route=$ROUTE status=$STATUS"
+CODE=$(curl -s -o /tmp/incident-snapshot.tar.gz -w '%{http_code}' "$URL" || echo 000)
+[ "$CODE" = "000" ] && { echo "export request failed (tunnel dropped?)"; exit 1; }
+
+if [ "$CODE" = "404" ]; then
+  echo
+  echo "  no failing traffic in the export scan right now."
+  echo "  errors fire in ~10-minute bursts; watch the errors dashboard and rerun"
+  echo "  this within a few minutes of a burst (or widen WINDOW=... once the"
+  echo "  replay-lab window param is deployed)."
+  exit 1
+elif [ "$CODE" != "200" ]; then
+  echo "  export failed: HTTP $CODE"; head -c 300 /tmp/incident-snapshot.tar.gz; echo
+  exit 1
+fi
+
+rm -rf incident && mkdir -p incident
+tar xzf /tmp/incident-snapshot.tar.gz -C incident
+# a mocks-only tarball (no localhost/) means the scan found downstream traffic
+# but no inbound requests matching route+status - same "between bursts" case as
+# a 404, the export just had mocks to return
+N=$(find incident/localhost -name '*.md' 2>/dev/null | wc -l | tr -d ' ' || true)
+if [ "$N" = "0" ]; then
+  echo
+  echo "  the scan window has no failing $ROUTE requests right now (mocks only)."
+  echo "  errors fire in ~10-minute bursts; rerun within a few minutes of a burst"
+  echo "  (watch the errors dashboard), or widen WINDOW=... once the replay-lab"
+  echo "  window param is deployed."
+  exit 1
+fi
+echo ">> pulled $N failing request(s) into incident/ ($(du -sh incident | cut -f1))"
+
+python3 ./craft-mocks.py incident incident-mocks
+
+echo
+echo "Next:"
+echo "  terminal 1:  make run MOCKS=incident-mocks"
+echo "  terminal 2:  make reproduce IN=incident/localhost   ->  RED  (prod failure, on your laptop)"
+echo "               make fix                                ->  GREEN (same request, 201)"

--- a/replay-lab-demo/reproduce.sh
+++ b/replay-lab-demo/reproduce.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 # Replay the captured production failure against the local service and report the result.
+# IN=incident/localhost replays a snapshot freshly pulled by incident.sh instead
+# of the committed capture.
 set -euo pipefail
 cd "$(dirname "$0")"
 PM="$HOME/.speedscale/proxymock"
 PORT="${PORT:-8087}"
+IN="${IN:-captured}"
 
 ./warmup.sh
 
 rm -rf out
-"$PM" replay --in captured --test-against "http://localhost:$PORT" --out out >/dev/null 2>&1 || true
+"$PM" replay --in "$IN" --test-against "http://localhost:$PORT" --out out >/dev/null 2>&1 || true
 code=$(grep -rohE '"statusCode":[0-9]+' out 2>/dev/null | grep -oE '[0-9]+' | head -1)
 
 echo

--- a/replay-lab-demo/run.sh
+++ b/replay-lab-demo/run.sh
@@ -20,10 +20,12 @@ if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
 fi
 
 # proxymock mock: app -> proxy :4140 -> recorded response (accounts, stripe, paypal, complyadvantage)
-"$PM" mock --in mocks --no-out >/tmp/replay-lab-mock.log 2>&1 &
+# MOCKS=incident-mocks serves the account-matched set staged by incident.sh
+MOCKS="${MOCKS:-mocks}"
+"$PM" mock --in "$MOCKS" --no-out >/tmp/replay-lab-mock.log 2>&1 &
 MOCK_PID=$!
 trap 'kill $MOCK_PID 2>/dev/null || true' EXIT
-echo ">> proxymock mock serving deps on :4140  (accounts, stripe, paypal, complyadvantage)"
+echo ">> proxymock mock serving deps on :4140 from $MOCKS/"
 
 # Which build is running? memo-bug defaults ON for the classic reproduce/fix loop;
 # the gate demo overrides per scenario (MEMO_BUG=false, CONTRACT_REFACTOR=true, ...).


### PR DESCRIPTION
Follows #240. The incident half of the demo now pulls its traffic live instead of replaying a committed file: `make incident` port-forwards `replay-lab-control` on staging-decoy, exports the failing deposit traffic from the BYOC bucket (filtered by service/route/status), and stages it under `incident/`. The pulled RRPair carries the same `traceparent` as the failing Jaeger span, closing the dashboard → trace → payload evidence chain.

The failing request NPEs before its downstream fan-out, so the export has no dependency traffic for that account — `craft-mocks.py` derives account-matched accounts-service mocks from the committed recordings (the balance PUT body is part of the mock signature, so it is computed per incident). `run.sh`/`reproduce.sh`/`fix.sh` take `MOCKS=`/`IN=` so the same red/green loop runs either the live pull or the committed offline fallback. Incident dirs are gitignored: pulled RRPairs carry live short-lived bearer tokens.

Errors fire in ~10-minute bursts and the deployed export scans only the newest batches, so `incident.sh` reports the between-bursts case (mocks-only 200 or 404) with guidance instead of dying silently; the `window`/`batches` params it already passes take effect when [replay-lab !61](https://gitlab.com/speedscale/replay-lab/-/merge_requests/61) deploys.

Verified live end to end: burst at 23:0x UTC, `make incident` pulled 4 failing requests and crafted mocks for the incident account (48481), replay reproduced the production 400/NPE locally, `make fix` turned the same request 201. Residual risk: craft-mocks.py assumes the incident is a deposit-shaped request (accountId + amount in the body); other routes need their own template mapping.