### PR TITLE
Harden incident.sh failure handling; use the deployed window scan

### DIFF
--- a/replay-lab-demo/README.md
+++ b/replay-lab-demo/README.md
@@ -89,8 +89,8 @@ The pulled RRPair carries the same `traceparent` as the failing span in the
 tracing backend, so the evidence chain is: dashboard shows the error rate, the
 trace shows a 48-byte request body it cannot give you, the RRPair is those 48
 bytes. Errors fire in bursts, so if `make incident` reports no failing traffic,
-rerun it a few minutes after the next burst (the export's `window` param widens
-the scan once replay-lab !61 is deployed).
+widen the scan with `WINDOW=6h make incident` (or rerun a few minutes after the
+next burst).
 
 **Offline fallback**: a committed capture of the same failure ships in
 `captured/`, so the loop also runs with no cluster access at all:

--- a/replay-lab-demo/incident.sh
+++ b/replay-lab-demo/incident.sh
@@ -10,11 +10,10 @@
 #   make reproduce IN=incident/localhost     # RED  (the captured prod 400)
 #   make fix                                 # GREEN (same request, 201)
 #
-# The errors fire in ~10 minute bursts and the deployed export scans only the
-# newest few minutes of a busy service, so a 404 here usually means "between
-# bursts" - wait for the next burst (watch the Grafana errors dashboard) and
-# rerun. Once replay-lab !61 is deployed the window/batches params below make
-# the pull time-insensitive.
+# The errors fire in ~10 minute bursts. Pass WINDOW to widen the export scan
+# past the newest few minutes (deployed since replay-lab v0.0.44) so the pull is
+# not sensitive to burst timing; a 404 or mocks-only result means no matching
+# failures in that window.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -22,45 +21,58 @@ CTX="${CTX:-do-nyc1-staging-decoy}"
 SERVICE="${SERVICE:-banking-transactions}"
 ROUTE="${ROUTE:-/api/transactions/deposit}"
 STATUS="${STATUS:-400}"
-WINDOW="${WINDOW:-45m}"     # inert until replay-lab !61 deploys, then honored
+WINDOW="${WINDOW:-45m}"
 BATCHES="${BATCHES:-2000}"
-LOCAL_PORT=28080
+LOCAL_PORT="${LOCAL_PORT:-28080}"
+SNAP=/tmp/incident-snapshot.tar.gz
 
 command -v kubectl >/dev/null || { echo "kubectl is required"; exit 1; }
 kubectl --context "$CTX" get ns replay-lab >/dev/null 2>&1 \
   || { echo "no access to context $CTX / namespace replay-lab"; exit 1; }
 
+# A stale port-forward (or anything) on the port answers /healthz but then drops
+# the export mid-stream, which is exactly the confusing failure to avoid.
+if lsof -nP -iTCP:"$LOCAL_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo ":$LOCAL_PORT is already in use (stale port-forward?). Free it or set LOCAL_PORT=..." >&2
+  lsof -nP -iTCP:"$LOCAL_PORT" -sTCP:LISTEN >&2
+  exit 1
+fi
+
 kubectl --context "$CTX" -n replay-lab port-forward svc/replay-lab-control "$LOCAL_PORT:80" >/dev/null 2>&1 &
 PF=$!
 trap 'kill $PF 2>/dev/null || true' EXIT
 
-# wait for the tunnel; curl 000 = not up yet
+# wait for the tunnel; curl -w prints 000 until it is up
 for _ in $(seq 1 15); do
-  READY=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$LOCAL_PORT/healthz" || echo 000)
-  [ "$READY" != "000" ] && break
+  READY=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$LOCAL_PORT/healthz" || true)
+  [ "$READY" != "000" ] && [ -n "$READY" ] && break
   sleep 1
 done
-[ "$READY" = "000" ] && { echo "port-forward to replay-lab-control never came up"; exit 1; }
+[ "${READY:-000}" = "000" ] && { echo "port-forward to replay-lab-control never came up"; exit 1; }
 
 URL="http://localhost:$LOCAL_PORT/api/snapshots/export?service=$SERVICE&route=$ROUTE&status=$STATUS&mocks=true&window=$WINDOW&batches=$BATCHES"
-echo ">> exporting failing traffic: service=$SERVICE route=$ROUTE status=$STATUS"
-CODE=$(curl -s -o /tmp/incident-snapshot.tar.gz -w '%{http_code}' "$URL" || echo 000)
-[ "$CODE" = "000" ] && { echo "export request failed (tunnel dropped?)"; exit 1; }
+echo ">> exporting failing traffic: service=$SERVICE route=$ROUTE status=$STATUS window=$WINDOW"
+CODE=$(curl -s -o "$SNAP" -w '%{http_code}' "$URL" || true)   # -w already yields 000 on failure
 
-if [ "$CODE" = "404" ]; then
+if [ "${CODE:-000}" = "000" ]; then
+  echo "  export request failed (tunnel dropped before it completed)"
+  exit 1
+elif [ "$CODE" = "404" ]; then
   echo
   echo "  no failing traffic in the export scan right now."
-  echo "  errors fire in ~10-minute bursts; watch the errors dashboard and rerun"
-  echo "  this within a few minutes of a burst (or widen WINDOW=... once the"
-  echo "  replay-lab window param is deployed)."
+  echo "  widen the scan with a larger WINDOW=... (e.g. WINDOW=6h), or rerun a few"
+  echo "  minutes after the next burst (watch the Grafana errors dashboard)."
   exit 1
 elif [ "$CODE" != "200" ]; then
-  echo "  export failed: HTTP $CODE"; head -c 300 /tmp/incident-snapshot.tar.gz; echo
+  # a non-200 body is a JSON error; only print it if it is actually text so a
+  # stray gzip never dumps binary to the terminal
+  echo "  export failed: HTTP $CODE"
+  if LC_ALL=C grep -Iq . "$SNAP" 2>/dev/null; then head -c 300 "$SNAP"; echo; fi
   exit 1
 fi
 
 rm -rf incident && mkdir -p incident
-tar xzf /tmp/incident-snapshot.tar.gz -C incident
+tar xzf "$SNAP" -C incident
 # a mocks-only tarball (no localhost/) means the scan found downstream traffic
 # but no inbound requests matching route+status - same "between bursts" case as
 # a 404, the export just had mocks to return
@@ -68,9 +80,8 @@ N=$(find incident/localhost -name '*.md' 2>/dev/null | wc -l | tr -d ' ' || true
 if [ "$N" = "0" ]; then
   echo
   echo "  the scan window has no failing $ROUTE requests right now (mocks only)."
-  echo "  errors fire in ~10-minute bursts; rerun within a few minutes of a burst"
-  echo "  (watch the errors dashboard), or widen WINDOW=... once the replay-lab"
-  echo "  window param is deployed."
+  echo "  widen the scan with a larger WINDOW=... (e.g. WINDOW=6h), or rerun a few"
+  echo "  minutes after the next burst (watch the Grafana errors dashboard)."
   exit 1
 fi
 echo ">> pulled $N failing request(s) into incident/ ($(du -sh incident | cut -f1))"


### PR DESCRIPTION
Follows #241. A live `make incident` run printed `HTTP 000000` and dumped a gzip body to the terminal — this fixes what caused that and drops the now-obsolete "window not deployed yet" caveats.

- `curl -w '%{http_code}'` already emits `000` on a failed connection, so the extra `|| echo 000` appended a second `000`. The `= "000"` guard then missed and the code fell through to `head -c 300` on a gzip, dumping binary. Now uses `|| true`, and the error-body print is guarded with `grep -I` so a stray gzip never reaches the terminal.
- Preflight the local port. A stale port-forward answers `/healthz` but drops the export mid-stream (the original confusing failure); now it fails early with a clear message. `LOCAL_PORT` is overridable.
- The `window`/`batches` scan shipped in replay-lab v0.0.44, so the "not yet deployed" notes are gone. `WINDOW=6h make incident` pulls hours of failing traffic regardless of burst timing.

Verified `WINDOW=6h` against the live export: 25 failing deposits pulled across 7 accounts, mocks crafted per account, all 25 reproduce 400 and turn 201 after the fix. No behavior change to the committed offline loop.