### PR TITLE
Re-sign pulled incident tokens so a pull never expires

### DIFF
--- a/replay-lab-demo/README.md
+++ b/replay-lab-demo/README.md
@@ -123,7 +123,13 @@ The committed `captured/` and `prod-suite/` files are earlier pulls of the same
 traffic, kept so the loops run offline. Nothing in either loop touches
 Speedscale's cloud: capture, storage, and replay all run on infrastructure you
 own. Incident pulls land in `incident/` and `incident-mocks/`, which are
-gitignored — they carry live (short-lived) bearer tokens from the capture.
+gitignored because they carry real captured bearer tokens.
+
+Captured tokens expire ~24h after they were minted in staging, so `make incident`
+re-signs each one with a far-future expiry using the demo JWT secret (the local
+equivalent of the capture-token blueprint a redacted BYOC replay uses). A pull is
+therefore good indefinitely, and re-running `make incident` regenerates it from
+current traffic regardless.
 
 ## What is real vs mocked
 
@@ -149,6 +155,7 @@ fix.patch                     the one-line null-guard fix (applied by `make fix`
 gate.sh                       the CI release gate (replay + --fail-if, exit code = verdict)
 incident.sh                   pull the live failing traffic from the replay-lab BYOC export
 craft-mocks.py                derive account-matched accounts mocks for a pulled incident
+refresh-tokens.py             re-sign pulled bearer tokens with a far-future expiry
 record-suite.sh               re-record prod-suite/ from a healthy build
 warmup.sh                     readiness probe shared by the replay scripts
 setup.sh run.sh reproduce.sh fix.sh   the steps, as plain scripts (make just calls them)

--- a/replay-lab-demo/incident.sh
+++ b/replay-lab-demo/incident.sh
@@ -86,6 +86,7 @@ if [ "$N" = "0" ]; then
 fi
 echo ">> pulled $N failing request(s) into incident/ ($(du -sh incident | cut -f1))"
 
+python3 ./refresh-tokens.py incident
 python3 ./craft-mocks.py incident incident-mocks
 
 echo

--- a/replay-lab-demo/refresh-tokens.py
+++ b/replay-lab-demo/refresh-tokens.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Re-sign the bearer tokens in a pulled incident so replay never 401s on expiry.
+
+Captured requests carry real staging JWTs with a ~24h expiry. Replayed against
+the local service (which shares the demo JWT secret) they authenticate fine, but
+a pull left overnight would expire. This rewrites each Authorization bearer with
+the same claims and a far-future expiry, re-signed with the demo secret - the
+local-demo equivalent of the capture-token blueprint a redacted BYOC replay uses
+to swap in a live token. The request signature (host/method/url/body) is
+unchanged, so proxymock still matches and replays exactly as captured.
+
+Usage: refresh-tokens.py <dir-with-localhost-rrpairs>
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+
+# The demo JWT secret, same value baked into run.sh / warmup.sh and the staging
+# banking-jwt-secret. Not a real credential - a committed demo key.
+SECRET = b"banking-app-super-secret-key-change-this-in-production-256-bit"
+FAR_FUTURE = 1893456000  # 2030-01-01, matches the committed offline capture
+
+
+def b64url_decode(s):
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def b64url_encode(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def resign(token):
+    """Return the token with exp bumped and re-signed, or None if not HS256 JWT."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        header = json.loads(b64url_decode(parts[0]))
+        payload = json.loads(b64url_decode(parts[1]))
+    except Exception:
+        return None
+    if header.get("alg") != "HS256":
+        return None
+    payload["exp"] = FAR_FUTURE
+    h = b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    p = b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    sig = b64url_encode(hmac.new(SECRET, f"{h}.{p}".encode(), hashlib.sha256).digest())
+    return f"{h}.{p}.{sig}"
+
+
+def main():
+    localhost = os.path.join(sys.argv[1], "localhost")
+    if not os.path.isdir(localhost):
+        print(f"no localhost/ under {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+    refreshed = 0
+    for name in sorted(os.listdir(localhost)):
+        if not name.endswith(".md"):
+            continue
+        path = os.path.join(localhost, name)
+        txt = open(path).read()
+        changed = False
+        for old in set(re.findall(r"Bearer ([A-Za-z0-9._-]+)", txt)):
+            new = resign(old)
+            if new and new != old:
+                txt = txt.replace(old, new)
+                changed = True
+        if changed:
+            open(path, "w").write(txt)
+            refreshed += 1
+    print(f"refreshed tokens in {refreshed} request(s) (exp -> 2030)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follows #242. Captured requests carry real staging JWTs with a ~24h expiry; replayed against the local service (same demo JWT secret) they authenticate, but a pull left overnight would 401. `refresh-tokens.py` re-signs each bearer with the same claims and a 2030 expiry using the demo secret — the local equivalent of the capture-token blueprint a redacted BYOC replay uses to swap in a live token. The request signature (host/method/url/body) is unchanged, so proxymock still matches and replays exactly as captured. `incident.sh` runs it right after the pull.

Verified: a refreshed 25-request pull authenticates with 0 401s, all 25 reproduce 400 with the NPE, and the re-signed HS256 tokens verify against the demo secret. No change to the committed offline loop (its token is already 2030).