### PR TITLE
Add uidemo.sh: proxymock web workspace for the demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ gate-out/
 replay-lab-demo/incident/
 replay-lab-demo/incident-mocks/
 replay-lab-demo/incident-out/
+replay-lab-demo/uidemo/

--- a/replay-lab-demo/uidemo.sh
+++ b/replay-lab-demo/uidemo.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# UI-driven demo helper: stage the pulled incident as a proxymock web workspace,
+# and drive reproduce/fix so the RESULTS render in the browser (proxymock web),
+# not the terminal. proxymock web is a traffic explorer + diff view; it does not
+# run replays itself, so this script triggers the replay and web shows the
+# outcome. Grafana carries the observability half; this carries the traffic half.
+#
+#   ./uidemo.sh setup       # pull incident + build the web workspace + start the buggy service
+#   ./uidemo.sh web         # launch proxymock web on the workspace (browser opens)
+#   ./uidemo.sh reproduce   # replay the failing deposits -> web shows 400s (reproduced)
+#   ./uidemo.sh fix         # apply the fix, replay -> web shows 201s (green)
+#   ./uidemo.sh reset       # restore the bug
+#   ./uidemo.sh down        # stop service + web
+set -euo pipefail
+cd "$(dirname "$0")"
+PM="$HOME/.speedscale/proxymock"
+PORT="${PORT:-8087}"
+WS="uidemo/proxymock"
+ROOT="$(cd .. && pwd)"
+
+case "${1:-}" in
+  setup)
+    [ -d incident/localhost ] || WINDOW="${WINDOW:-6h}" ./incident.sh
+    rm -rf uidemo && mkdir -p "$WS"
+    # the pulled PRODUCTION traffic (failing deposits, as captured = 400) is the
+    # opening view: "here is your production traffic, from your own bucket"
+    cp -R incident/localhost "$WS/captured-production"
+    cp -R incident/banking-accounts "$WS/dependencies" 2>/dev/null || true
+    make down >/dev/null 2>&1 || true
+    MOCKS=incident-mocks ./run.sh > /tmp/uidemo-run.log 2>&1 &
+    echo ">> workspace built at $WS ; buggy service starting (see /tmp/uidemo-run.log)"
+    echo ">> next: ./uidemo.sh web"
+    ;;
+  web)
+    echo ">> opening proxymock web on the workspace (traffic explorer)"
+    exec "$PM" web --in uidemo --forwarder-addr "" --port 7799
+    ;;
+  reproduce)
+    ./warmup.sh
+    rm -rf "$WS/reproduced"
+    "$PM" replay --in incident/localhost --test-against "http://localhost:$PORT" --out "$WS/reproduced" >/dev/null 2>&1 || true
+    n=$(grep -rl '"statusCode":400' "$WS/reproduced" 2>/dev/null | wc -l | tr -d ' ')
+    echo ">> reproduced: $n deposits returned 400 (refresh proxymock web -> the reproduced/ set)"
+    ;;
+  fix)
+    ( cd "$ROOT" && git apply replay-lab-demo/fix.patch && ( cd backend/transactions-service && mvn -q -o compile ) )
+    echo ">> fix applied, hot-restarting"; sleep 12
+    ./warmup.sh
+    rm -rf "$WS/fixed"
+    "$PM" replay --in incident/localhost --test-against "http://localhost:$PORT" --out "$WS/fixed" >/dev/null 2>&1 || true
+    n=$(grep -rl '"statusCode":201' "$WS/fixed" 2>/dev/null | wc -l | tr -d ' ')
+    echo ">> fixed: $n deposits returned 201 (refresh proxymock web -> the fixed/ set)"
+    ;;
+  reset)
+    ( cd "$ROOT" && git checkout -- backend/transactions-service ) && echo ">> bug restored"
+    ;;
+  down)
+    pkill -f "proxymock web" 2>/dev/null || true
+    make down >/dev/null 2>&1 || true
+    echo ">> stopped web + service"
+    ;;
+  *)
+    grep -E '^#   \./uidemo\.sh' "$0" | sed 's/^#   //'
+    ;;
+esac


### PR DESCRIPTION
Follows #244. Makes the incident reproduce/fix showable in **proxymock web** (the traffic explorer) instead of terminal output, for demos to a mixed audience.

`uidemo.sh` stages the pulled incident as a proxymock web workspace (`uidemo/proxymock/`) and drives the loop so the results render in the browser:
- `setup` — pull incident, build the workspace, start the buggy service
- `web` — launch proxymock web on the workspace
- `reproduce` / `fix` — replay against buggy/fixed build; web shows 400 then 201
- `reset` / `down`

proxymock web is an explorer + diff view with no replay button, so the script triggers each replay and web shows the outcome. Grafana still carries observability. Verified via the proxymock web API: the workspace loads all 63 pulled RRPairs, and the reproduced (25×400) and fixed (25×201) sets render. The generated `uidemo/` dir is gitignored (pulled traffic + short-lived tokens). No change to the existing make flow, which stays the reliable fallback.