### PR TITLE
Raise sim error injection to 0.3 for denser demo deposit errors

### DIFF
--- a/kubernetes/base/configmaps/simulation-client-configmap.yaml
+++ b/kubernetes/base/configmaps/simulation-client-configmap.yaml
@@ -35,8 +35,11 @@ data:
   BURST_DURATION_MS: "30000"      # each burst lasts ~30s
   BURST_JITTER_MS: "60000"        # ±60s randomness on interval
 
-  # Negative-path traffic stays light so localized service errors remain visible.
-  ERROR_INJECTION_PROBABILITY: "0.05"
+  # Per session, chance of running one injected "unhappy path". One of five is the
+  # null-description deposit (the Replay Lab 400 fixture), so failing deposits land
+  # on ~ERROR_INJECTION_PROBABILITY/5 of sessions. Raised from 0.05 so the deposit
+  # errors are dense enough to find and pull in the Replay Lab demo.
+  ERROR_INJECTION_PROBABILITY: "0.3"
 
   # User pool configuration
   TOTAL_USERS: "1000"


### PR DESCRIPTION
# Problem

The banking-sim runs with `ERROR_INJECTION_PROBABILITY=0.05`. The null-description deposit — the Replay Lab 400 fixture — is 1 of 5 injected error scenarios, so failing deposits land on only ~1% of sessions. That is too sparse to reliably find and pull for the Replay Lab demo: a status=400 import over a few minutes returns only a handful, and they are buried under Postgres/200 traffic.

# Solution

Bump `ERROR_INJECTION_PROBABILITY` to 0.3 in the base sim ConfigMap. Failing deposits now land on ~6% of sessions (0.3 / 5), dense enough to filter and import by `status=400` in proxymock web. The other injected error types (401/404/409/503) rise proportionally but stay modest, and the scheduled spike behavior is unchanged. No overlay overrides this key, so it applies to staging-decoy on ArgoCD sync.

Config-only change; no image rebuild.