### PR TITLE
Remove sidecar TLS-out from responder TRs to fix eBPF init failures

### DIFF
--- a/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-accounts.yaml
@@ -9,9 +9,10 @@ spec:
   testConfigID: banking-mock-fail-closed
   # responder-only = fail-closed: 404 on no-match, NO passthrough to real dependency
   mode: responder-only
-  sidecar:
-    tls:
-      out: true
+  # No sidecar block: these workloads use eBPF/java-agent capture
+  # (capture.speedscale.com/*), and the operator webhook rejects goproxy
+  # inject alongside capture annotations. Responder reroute attaches via the
+  # initproxy whenever the replay has a responder service - no sidecar needed.
   workloadRef:
     kind: Deployment
     name: banking-accounts

--- a/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-ai.yaml
@@ -7,9 +7,10 @@ spec:
   snapshotID: 7f7256a0-8876-4e3f-aea9-3fd681e0c36a
   testConfigID: banking-mock-fail-closed
   mode: responder-only
-  sidecar:
-    tls:
-      out: true
+  # No sidecar block: these workloads use eBPF/java-agent capture
+  # (capture.speedscale.com/*), and the operator webhook rejects goproxy
+  # inject alongside capture annotations. Responder reroute attaches via the
+  # initproxy whenever the replay has a responder service - no sidecar needed.
   workloadRef:
     kind: Deployment
     name: banking-ai

--- a/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-fraud.yaml
@@ -7,9 +7,10 @@ spec:
   snapshotID: c3898583-282b-4b82-9bdb-72b7dd45d15c
   testConfigID: banking-mock-fail-closed
   mode: responder-only
-  sidecar:
-    tls:
-      out: true
+  # No sidecar block: these workloads use eBPF/java-agent capture
+  # (capture.speedscale.com/*), and the operator webhook rejects goproxy
+  # inject alongside capture annotations. Responder reroute attaches via the
+  # initproxy whenever the replay has a responder service - no sidecar needed.
   workloadRef:
     kind: Deployment
     name: banking-fraud

--- a/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-notification.yaml
@@ -7,9 +7,10 @@ spec:
   snapshotID: ae1d6748-ae79-4334-9fcc-0d634de79e75
   testConfigID: banking-mock-fail-closed
   mode: responder-only
-  sidecar:
-    tls:
-      out: true
+  # No sidecar block: these workloads use eBPF/java-agent capture
+  # (capture.speedscale.com/*), and the operator webhook rejects goproxy
+  # inject alongside capture annotations. Responder reroute attaches via the
+  # initproxy whenever the replay has a responder service - no sidecar needed.
   workloadRef:
     kind: Deployment
     name: banking-notification

--- a/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-transactions.yaml
@@ -7,9 +7,10 @@ spec:
   snapshotID: c7bc4b14-40bd-46ae-88fd-f366b36de453
   testConfigID: banking-mock-fail-closed
   mode: responder-only
-  sidecar:
-    tls:
-      out: true
+  # No sidecar block: these workloads use eBPF/java-agent capture
+  # (capture.speedscale.com/*), and the operator webhook rejects goproxy
+  # inject alongside capture annotations. Responder reroute attaches via the
+  # initproxy whenever the replay has a responder service - no sidecar needed.
   workloadRef:
     kind: Deployment
     name: banking-transactions

--- a/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
+++ b/kubernetes/overlays/speedscale/responders/replay-banking-user.yaml
@@ -7,9 +7,10 @@ spec:
   snapshotID: 68d2bc15-8931-4093-836e-a5ba3a5a5b5a
   testConfigID: banking-mock-fail-closed
   mode: responder-only
-  sidecar:
-    tls:
-      out: true
+  # No sidecar block: these workloads use eBPF/java-agent capture
+  # (capture.speedscale.com/*), and the operator webhook rejects goproxy
+  # inject alongside capture annotations. Responder reroute attaches via the
+  # initproxy whenever the replay has a responder service - no sidecar needed.
   workloadRef:
     kind: Deployment
     name: banking-user


### PR DESCRIPTION
## Problem

All six responder `TrafficReplay`s on the eBPF/java-agent overlay (dev-decoy) are stuck in `Failed to init`:

```
admission webhook "sidecar.speedscale.com" denied the request: Invalid workload
configuration: "capture.speedscale.com/java-agent" cannot be used in conjunction
with "sidecar.speedscale.com/inject"
```

#239 removed the `sidecar.speedscale.com/*` annotations from the TR metadata but left `spec.sidecar.tls.out: true` in place. The operator still reads that block and tries to inject goproxy for TLS-out, patching `sidecar.speedscale.com/inject` onto the workload — which the webhook rejects because these workloads carry `capture.speedscale.com/*` capture annotations. So #239 only half-fixed it; the replays still fail at init.

Staging-decoy is unaffected only because it is still on older manifests without the `java-agent` capture annotation.

## Solution

Drop the `spec.sidecar` block from all six responder TRs. Responder reroute attaches via the initproxy whenever the replay has a responder service and never needed the sidecar; the block only added goproxy for TLS-out, which is exactly what the operator hardening forbids on capture workloads. A comment now documents why the block must stay absent, to prevent it creeping back.

No-op for the `speedscale-sidecar` overlay, whose workloads inject at the workload level.

## Verification

- Root cause confirmed against live dev-decoy: identical operator version (`v2.5.744`) on both clusters; the only difference is the `capture.speedscale.com/java-agent` annotation on dev workloads plus the residual `spec.sidecar.tls.out`.
- The separately-fixed Moody's/OXR/Plaid mock data in snapshot `25ef64bf` is already re-pushed to both tenants; once ArgoCD syncs this and the dev responders init, dev-decoy will serve the corrected JSON.
- Post-merge: confirm the six TRs reach `Running` on dev-decoy and a responder pod comes up per service.