### PR TITLE
Fix OOMKill loops on banking-frontend and banking-kafka

### DIFF
--- a/kubernetes/base/deployments/frontend-deployment.yaml
+++ b/kubernetes/base/deployments/frontend-deployment.yaml
@@ -39,10 +39,12 @@ spec:
           value: "http://banking-ai:8080"
         resources:
           requests:
-            memory: "128Mi"
+            # Steady state sits near 200Mi, so the old 256Mi ceiling OOMKilled
+            # the container on every traffic burst (160 restarts in staging).
+            memory: "256Mi"
             cpu: "100m"
           limits:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "200m"
         livenessProbe:
           httpGet:

--- a/kubernetes/base/kafka/kafka-deployment.yaml
+++ b/kubernetes/base/kafka/kafka-deployment.yaml
@@ -57,12 +57,17 @@ spec:
           value: "CONTROLLER"
         - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
           value: "true"
+        # The image defaults the heap to 1g, which cannot fit the container
+        # limit below. Left unset the broker OOMKilled under load (88 restarts
+        # in staging); pin the heap so heap plus off-heap stays under the limit.
+        - name: KAFKA_HEAP_OPTS
+          value: "-Xmx512m -Xms256m"
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "100m"
           limits:
-            memory: "512Mi"
+            memory: "1Gi"
             cpu: "300m"
         readinessProbe:
           tcpSocket:


### PR DESCRIPTION
# Problem

Two containers in `banking-app` are stuck in OOMKill loops in staging:

- `banking-frontend` has restarted **160 times**. The container runs at ~200Mi steady state against a 256Mi limit, so any traffic burst kills it.
- `banking-kafka` has restarted **88 times**. The image defaults `KAFKA_HEAP_OPTS` to a 1g heap, which cannot fit inside the 512Mi container limit, so the broker is killed as soon as the heap grows.

Neither shows up as an API error, so traffic-level dashboards read clean while the frontend and the notification path keep dropping.

Measured with `kubectl top pods --containers` against staging: frontend 199Mi / 256Mi limit, kafka 420Mi / 512Mi limit.

# Solution

- frontend: request 128Mi -> 256Mi, limit 256Mi -> 512Mi.
- kafka: pin `KAFKA_HEAP_OPTS` to `-Xmx512m -Xms256m` rather than inheriting the image default, request 256Mi -> 512Mi, limit 512Mi -> 1Gi so heap plus off-heap fits.

CPU limits, image tags, and every other field are untouched. `kustomize build kubernetes/base` renders clean.

Residual risk: the new ceilings are sized from one steady-state sample plus burst headroom, not from a load test. If the frontend's real peak is above 512Mi it will still OOM, just less often, and the numbers should be raised again. Kafka's 512m heap is a demo-scale choice; a busier broker would need more.

Worth noting separately: the `speedscale-goproxy` sidecar on the frontend pod is using 614Mi with no memory limit set. That is not addressed here.