### PR TITLE
DRAFT: pin proxymock in CI (does NOT fix the red build - see body)

### DIFF
--- a/scripts/run-proxymock-validation.sh
+++ b/scripts/run-proxymock-validation.sh
@@ -19,9 +19,15 @@ cd "$ROOT"
 
 export PATH="${HOME}/.speedscale:${PATH}"
 
+# Installing unpinned made this job a moving target: v2.5.768 passed on
+# 2026-07-14 and v2.5.846 fails the Postgres step, with Npgsql reporting
+# "Severity not received in server error message" against the mock on 5432.
+# Pin to the last known-good build; override to retest a newer one.
+PROXYMOCK_VERSION="${PROXYMOCK_VERSION:-v2.5.768}"
+
 if ! command -v proxymock >/dev/null 2>&1; then
-  echo "Installing proxymock to ${HOME}/.speedscale ..."
-  curl -Lfs https://downloads.speedscale.com/proxymock/install-proxymock | sh
+  echo "Installing proxymock ${PROXYMOCK_VERSION} to ${HOME}/.speedscale ..."
+  curl -Lfs https://downloads.speedscale.com/proxymock/install-proxymock | sh -s -- "${PROXYMOCK_VERSION}"
   export PATH="${HOME}/.speedscale:${PATH}"
 fi
 


### PR DESCRIPTION
# Retracted diagnosis

I opened this claiming the CI failure was a proxymock regression between v2.5.768 and v2.5.846. **That was wrong.** This PR went green by coincidence, not because the pin fixed anything. Do not merge it as a fix.

Local A/B, running the repo's own `scripts/test-postgres-mock.sh` in a container against the same recording:

| proxymock | Result |
|---|---|
| v2.5.846 | schema bootstrap fails 8/8, `unexpected EOF` |
| v2.5.768 | schema bootstrap fails 8/8, `Severity not received in server error message` |

Both versions fail identically, so the version is not the variable. The green run on this branch carries the *same* `unexpected EOF` lines and a `responder miss: query` — the symptoms I pointed at are present in passing runs too.

# The actual failure

The job's pass/fail hinges on a 60-second readiness window in `scripts/test-postgres-mock.sh`:

- Red runs (#250, #251): `Timed out waiting for something to listen on 127.0.0.1:8080` after 60 attempts, then `exit 1`.
- Green run (this branch): `Health OK: http://127.0.0.1:8080/actuator/health`.

The mock has no recorded response for Npgsql's startup type-catalog query (`SELECT version(); SELECT ns.nspname, t.oid, ...`), logged as `responder miss: query`. user-service retries its schema bootstrap 8 times with backoff before starting anyway, and on a slower runner that pushes the listen past the 60s deadline. It is a race, so it can pass or fail on identical code.

# What would actually fix it

Either add the Npgsql catalog query to the recording so the bootstrap succeeds on the first attempt, or stop the bootstrap retries from gating startup and give the readiness wait realistic headroom. The first is the better fix: the fixture is incomplete, and the timeout is only where the incompleteness surfaces.

Leaving this as a draft. The version pin is defensible on its own for build determinism, but it is not the fix and the original body's reasoning was unsound.